### PR TITLE
Add parallax dust and scene images

### DIFF
--- a/src/components/ParallaxDust.jsx
+++ b/src/components/ParallaxDust.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import "./styles/ParallaxDust.css";
+
+function ParallaxDust() {
+  return (
+    <div className="dust-layer">
+      <div className="dust dust1" />
+      <div className="dust dust2" />
+      <div className="dust dust3" />
+    </div>
+  );
+}
+
+export default ParallaxDust;

--- a/src/components/phases/FinalBossPhase.jsx
+++ b/src/components/phases/FinalBossPhase.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from "react";
+import ParallaxDust from "../ParallaxDust";
+import "../styles/RoomScene.css";
 
 function FinalBossPhase({ setGameState }) {
   const [timer, setTimer] = useState(0);
@@ -38,6 +40,8 @@ function FinalBossPhase({ setGameState }) {
 
   return (
     <div className="room-container">
+      <img src="/FitnessSuite.png" alt="Fitness Suite" className="scene-image" />
+      <ParallaxDust />
       <h1>🏋️ Final Battle: Operation Slamstorm</h1>
       <h2>🔥 Hero Workout: 21-15-9</h2>
       <ul>

--- a/src/components/phases/IntroPhase.jsx
+++ b/src/components/phases/IntroPhase.jsx
@@ -1,8 +1,12 @@
 import React from "react";
+import ParallaxDust from "../ParallaxDust";
+import "../styles/RoomScene.css";
 
 function IntroPhase({ setGameState }) {
   return (
-    <div style={{ padding: 20 }}>
+    <div className="room-container">
+      <img src="/locker_Room.png" alt="Locker Room" className="scene-image" />
+      <ParallaxDust />
       <h2>🧊 Locked In</h2>
       <p>
         You were stuffed into a locker by bullies. You shouted for help, but no one came.

--- a/src/components/phases/Room1.jsx
+++ b/src/components/phases/Room1.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import WorkoutLogger from "../WorkoutLogger";
+import ParallaxDust from "../ParallaxDust";
+import "../styles/RoomScene.css";
 
 function Room1({ setGameState, gameState }) {
   const [workoutUploaded, setWorkoutUploaded] = useState(false);
@@ -63,6 +65,8 @@ function Room1({ setGameState, gameState }) {
 
   return (
     <div className="room-container">
+      <img src="/Mr_WatkinsRoom.png" alt="Mr Watkins' Room" className="scene-image" />
+      <ParallaxDust />
       <h1>Mr. Watkins' Room</h1>
 
       {!workoutUploaded && (

--- a/src/components/phases/Room2.jsx
+++ b/src/components/phases/Room2.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import WorkoutLogger from "../WorkoutLogger";
 import SafeQuizEvent from "../events/SafeQuizEvent";
+import ParallaxDust from "../ParallaxDust";
+import "../styles/RoomScene.css";
 
 const languageQuestions = [
   {
@@ -110,6 +112,8 @@ function Room2({ setGameState, gameState }) {
 
   return (
     <div className="room-container">
+      <img src="/Mrs_JohnsRoom.png" alt="Mrs. John's Room" className="scene-image" />
+      <ParallaxDust />
       <h1>Mrs. John's Room</h1>
 
       {!workoutUploaded && (

--- a/src/components/phases/Room3Boss.jsx
+++ b/src/components/phases/Room3Boss.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
 import WorkoutLogger from "../WorkoutLogger";
 import QuizPhase from "./QuizPhase";
+import ParallaxDust from "../ParallaxDust";
 import "../styles/Room3Boss.css";
+import "../styles/RoomScene.css";
 
 const bossQuizQuestions = [
   {
@@ -98,6 +100,8 @@ function Room3Boss({ setGameState, gameState }) {
 
   return (
     <div className="room-container">
+      <img src="/Mrs_RochesRoom.png" alt="Mrs. Roche's Room" className="scene-image" />
+      <ParallaxDust />
       <h1>Mrs. Roche's Classroom</h1>
 
       {bossPhase === 0 && !workoutLogged && (

--- a/src/components/styles/Map.css
+++ b/src/components/styles/Map.css
@@ -1,6 +1,10 @@
 /* General Map Container Styling */
 .map-container {
   background-color: #1b1b1b;
+  background-image: url('/global-bg.png');
+  background-size: cover;
+  background-position: center;
+  background-blend-mode: multiply;
   border: 4px solid #333;
   border-radius: 8px;
   padding: 20px;

--- a/src/components/styles/ParallaxDust.css
+++ b/src/components/styles/ParallaxDust.css
@@ -1,0 +1,42 @@
+.dust-layer {
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  z-index: 1;
+}
+
+.dust {
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.3) 1px, transparent 1px);
+  background-size: 3px 3px;
+  animation: dust-float 40s linear infinite;
+}
+
+.dust1 {
+  animation-duration: 40s;
+}
+
+.dust2 {
+  animation-duration: 55s;
+}
+
+.dust3 {
+  animation-duration: 70s;
+}
+
+@keyframes dust-float {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(50%, -50%, 0);
+  }
+}

--- a/src/components/styles/RoomScene.css
+++ b/src/components/styles/RoomScene.css
@@ -1,0 +1,13 @@
+.room-container {
+  position: relative;
+  overflow: hidden;
+  padding: 20px;
+  color: #fff;
+  text-align: center;
+}
+
+.scene-image {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 15px;
+}


### PR DESCRIPTION
## Summary
- add ParallaxDust component with simple floating particles
- introduce RoomScene styles
- display images for locker room, classrooms and fitness suite
- add parallax dust overlay to scene components
- improve map styling with background image

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c9ef41160832fad1c6e2b583c2ff4