### PR TITLE
Add devcontainer config with allowed hostnames

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "Node DevContainer",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
+  "security": {
+    "allowedHostnames": [
+      "registry.npmjs.org",
+      "vitejs.dev"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `.devcontainer/devcontainer.json` enabling npmjs.org and vitejs.dev

## Testing
- `npm install --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ca15fd718832fbdfa2af7083e1ae3