### PR TITLE
Add RPG overlay and flashing blaze pods

### DIFF
--- a/src/components/BlazePods.jsx
+++ b/src/components/BlazePods.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import "./styles/BlazePods.css";
+
+function BlazePods({ count = 4 }) {
+  const pods = Array.from({ length: count });
+  return (
+    <div className="blaze-pods">
+      {pods.map((_, i) => (
+        <div key={i} className="blaze-pod" style={{ animationDelay: `${i * 0.2}s` }} />
+      ))}
+    </div>
+  );
+}
+
+export default BlazePods;

--- a/src/components/phases/FinalBossPhase.jsx
+++ b/src/components/phases/FinalBossPhase.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import ParallaxDust from "../ParallaxDust";
+import BlazePods from "../BlazePods";
 import "../styles/RoomScene.css";
 
 function FinalBossPhase({ setGameState }) {
@@ -39,16 +40,18 @@ function FinalBossPhase({ setGameState }) {
   };
 
   return (
-    <div className="room-container">
+    <div className={`room-container ${battleStarted ? "interaction" : ""}`}>
       <img src="/FitnessSuite.png" alt="Fitness Suite" className="scene-image" />
       <ParallaxDust />
-      <h1>🏋️ Final Battle: Operation Slamstorm</h1>
-      <h2>🔥 Hero Workout: 21-15-9</h2>
-      <ul>
-        <li>21 Calories on Assault Bike</li>
-        <li>15 Slam Balls</li>
-        <li>9 Burpees</li>
-      </ul>
+      <BlazePods />
+      <div className="room-content rpg-text">
+        <h1>🏋️ Final Battle: Operation Slamstorm</h1>
+        <h2>🔥 Hero Workout: 21-15-9</h2>
+        <ul>
+          <li>21 Calories on Assault Bike</li>
+          <li>15 Slam Balls</li>
+          <li>9 Burpees</li>
+        </ul>
 
       {!battleStarted && (
         <>
@@ -73,16 +76,17 @@ function FinalBossPhase({ setGameState }) {
         </>
       )}
 
-      {battleFinished && (
-        <div className="victory-summary">
-          <h3>🎉 Victory Achieved!</h3>
+        {battleFinished && (
+          <div className="victory-summary">
+            <h3>🎉 Victory Achieved!</h3>
           <p>Mutated Mrs. Roche collapses in defeat, the air clearing as silence returns.</p>
           <p>You completed <strong>Operation Slamstorm</strong> in <strong>{timer} seconds</strong>.</p>
           <p>Your heroic effort has been immortalized on the school leaderboard.</p>
+          </div>
+        )}
         </div>
-      )}
-    </div>
-  );
+      </div>
+    );
 }
 
 export default FinalBossPhase;

--- a/src/components/phases/IntroPhase.jsx
+++ b/src/components/phases/IntroPhase.jsx
@@ -7,25 +7,27 @@ function IntroPhase({ setGameState }) {
     <div className="room-container">
       <img src="/locker_Room.png" alt="Locker Room" className="scene-image" />
       <ParallaxDust />
-      <h2>🧊 Locked In</h2>
-      <p>
-        You were stuffed into a locker by bullies. You shouted for help, but no one came.
-        Then… the evacuation alarm rang. Panic erupted outside. You screamed… and passed
-        out from the lack of air.
-      </p>
-      <p>⏱️ 24 hours later…</p>
-      <p>
-        You awake—cold, cramped, and alone. The building is silent. Lights flicker. You
-        scream again… nothing.
-      </p>
-      <p>
-        💥 Using the last of your strength, you kick the locker door until it swings open.
-        You collapse out onto the changing room floor, freezing cold.
-      </p>
-      <p>You must get warm fast or risk freezing in the dark...</p>
-      <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 1 }))}>
-        Get Moving
-      </button>
+      <div className="room-content rpg-text">
+        <h2>🧊 Locked In</h2>
+        <p>
+          You were stuffed into a locker by bullies. You shouted for help, but no one came.
+          Then… the evacuation alarm rang. Panic erupted outside. You screamed… and passed
+          out from the lack of air.
+        </p>
+        <p>⏱️ 24 hours later…</p>
+        <p>
+          You awake—cold, cramped, and alone. The building is silent. Lights flicker. You
+          scream again… nothing.
+        </p>
+        <p>
+          💥 Using the last of your strength, you kick the locker door until it swings open.
+          You collapse out onto the changing room floor, freezing cold.
+        </p>
+        <p>You must get warm fast or risk freezing in the dark...</p>
+        <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 1 }))}>
+          Get Moving
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/phases/Room1.jsx
+++ b/src/components/phases/Room1.jsx
@@ -64,22 +64,23 @@ function Room1({ setGameState, gameState }) {
   };
 
   return (
-    <div className="room-container">
+    <div className={`room-container ${!workoutUploaded ? "interaction" : ""}`}>
       <img src="/Mr_WatkinsRoom.png" alt="Mr Watkins' Room" className="scene-image" />
       <ParallaxDust />
-      <h1>Mr. Watkins' Room</h1>
+      <div className="room-content rpg-text">
+        <h1>Mr. Watkins' Room</h1>
 
-      {!workoutUploaded && (
-        <>
-          <p>You cautiously enter the abandoned classroom. The stale air and dust hint that no one has been here for a while. It's the perfect moment to focus and log your workout.</p>
-          <WorkoutLogger
-            roomNumber={1}
-            setGameState={setGameState}
-            workoutFocus={gameState.workoutFocus}
-          />
-          <button onClick={handleUploadWorkout}>Upload Your Workout</button>
-        </>
-      )}
+        {!workoutUploaded && (
+          <>
+            <p>You cautiously enter the abandoned classroom. The stale air and dust hint that no one has been here for a while. It's the perfect moment to focus and log your workout.</p>
+            <WorkoutLogger
+              roomNumber={1}
+              setGameState={setGameState}
+              workoutFocus={gameState.workoutFocus}
+            />
+            <button onClick={handleUploadWorkout}>Upload Your Workout</button>
+          </>
+        )}
 
       {workoutUploaded && !scavengeCompleted && (
         <>
@@ -92,12 +93,13 @@ function Room1({ setGameState, gameState }) {
         <p>You pocket the <strong>{foundItem}</strong>. It shows another room labeled "Mrs. John's Room" – previously unknown. A breakthrough!</p>
       )}
 
-      {restReady && (
-        <>
-          <p>Feeling the fatigue set in, you choose to rest in a safe corner. Tomorrow, you'll explore the newly revealed room.</p>
-          <button onClick={handleRest}>Rest Up for the Night</button>
-        </>
-      )}
+        {restReady && (
+          <>
+            <p>Feeling the fatigue set in, you choose to rest in a safe corner. Tomorrow, you'll explore the newly revealed room.</p>
+            <button onClick={handleRest}>Rest Up for the Night</button>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/phases/Room2.jsx
+++ b/src/components/phases/Room2.jsx
@@ -111,10 +111,11 @@ function Room2({ setGameState, gameState }) {
   };
 
   return (
-    <div className="room-container">
+    <div className={`room-container ${(!workoutUploaded || quizActive) ? "interaction" : ""}`}>
       <img src="/Mrs_JohnsRoom.png" alt="Mrs. John's Room" className="scene-image" />
       <ParallaxDust />
-      <h1>Mrs. John's Room</h1>
+      <div className="room-content rpg-text">
+        <h1>Mrs. John's Room</h1>
 
       {!workoutUploaded && (
         <>
@@ -168,6 +169,7 @@ function Room2({ setGameState, gameState }) {
           <button onClick={handleReturnToMap}>Return to the Map</button>
         </>
       )}
+      </div>
     </div>
   );
 }

--- a/src/components/phases/Room3Boss.jsx
+++ b/src/components/phases/Room3Boss.jsx
@@ -99,10 +99,11 @@ function Room3Boss({ setGameState, gameState }) {
   };
 
   return (
-    <div className="room-container">
+    <div className={`room-container ${((bossPhase === 0 && !workoutLogged) || quizStarted || bossPhase > 0) ? "interaction" : ""}`}>
       <img src="/Mrs_RochesRoom.png" alt="Mrs. Roche's Room" className="scene-image" />
       <ParallaxDust />
-      <h1>Mrs. Roche's Classroom</h1>
+      <div className="room-content rpg-text">
+        <h1>Mrs. Roche's Classroom</h1>
 
       {bossPhase === 0 && !workoutLogged && (
         <>
@@ -163,6 +164,7 @@ function Room3Boss({ setGameState, gameState }) {
           <button onClick={handlePhaseTwoComplete}>Run for the door!</button>
         </>
       )}
+      </div>
     </div>
   );
 }

--- a/src/components/styles/BlazePods.css
+++ b/src/components/styles/BlazePods.css
@@ -1,0 +1,24 @@
+.blaze-pods {
+  position: absolute;
+  bottom: 30px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.blaze-pod {
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  background: red;
+  opacity: 0.2;
+  animation: blaze-flash 1s infinite;
+}
+
+@keyframes blaze-flash {
+  0%, 100% { opacity: 0.2; }
+  50% { opacity: 1; }
+}

--- a/src/components/styles/RoomScene.css
+++ b/src/components/styles/RoomScene.css
@@ -11,3 +11,28 @@
   border-radius: 8px;
   margin-bottom: 15px;
 }
+.room-content {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.4);
+  text-align: center;
+}
+
+.rpg-text {
+  font-family: "Papyrus", fantasy;
+  text-shadow: 2px 2px 4px #000;
+}
+
+.room-container.interaction .scene-image {
+  opacity: 0.3;
+  transform: scale(0.95);
+  transition: opacity 0.3s, transform 0.3s;
+}


### PR DESCRIPTION
## Summary
- overlay narration on scene images with fantasy styling
- dim background during interactive workout/quiz moments
- add BlazePods component for flashing pods in the Fitness Suite
- update intro and room phases to use the new overlay styles

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ca51fa520832f95701a9422c2c3ea