### PR TITLE
Add scenes and icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "vite": "^6.3.5"
       }
     },
@@ -831,6 +832,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "vite": "^6.3.5"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,7 +23,7 @@ function App() {
     yearGroup: "",
     gender: "",
     workoutFocus: "",
-    avatar: "🙂",
+    avatar: "pirate",
     introStage: 0,
     currentRoom: null,
     completedRooms: [],

--- a/src/components/CharacterCreation.jsx
+++ b/src/components/CharacterCreation.jsx
@@ -1,8 +1,13 @@
 import React from "react";
+import { GiPirateCaptain, GiBlackKnightHelm, GiNinjaHead } from "react-icons/gi";
 import "./styles/CharacterCreation.css";
 
 function CharacterCreation({ gameState, setGameState }) {
-  const avatars = ["🙂", "😎", "👾"];
+  const avatars = [
+    { id: "pirate", icon: <GiPirateCaptain /> },
+    { id: "knight", icon: <GiBlackKnightHelm /> },
+    { id: "ninja", icon: <GiNinjaHead /> },
+  ];
 
   return (
     <div className="character-creation-container">
@@ -49,13 +54,13 @@ function CharacterCreation({ gameState, setGameState }) {
           <option value="strength">Strength</option>
         </select>
         <div className="avatar-selection">
-          {avatars.map((av) => (
+          {avatars.map(({ id, icon }) => (
             <span
-              key={av}
-              className={`avatar-option ${gameState.avatar === av ? "selected" : ""}`}
-              onClick={() => setGameState({ ...gameState, avatar: av })}
+              key={id}
+              className={`avatar-option ${gameState.avatar === id ? "selected" : ""}`}
+              onClick={() => setGameState({ ...gameState, avatar: id })}
             >
-              {av}
+              {icon}
             </span>
           ))}
         </div>

--- a/src/components/RoomNarrativeOverlay.jsx
+++ b/src/components/RoomNarrativeOverlay.jsx
@@ -1,5 +1,12 @@
 import React from "react";
+import { GiPirateCaptain, GiBlackKnightHelm, GiNinjaHead } from "react-icons/gi";
 import "./styles/Overlay.css";
+
+const avatarIcons = {
+  pirate: <GiPirateCaptain />,
+  knight: <GiBlackKnightHelm />,
+  ninja: <GiNinjaHead />,
+};
 
 function RoomNarrativeOverlay({ roomName, avatar, onContinue }) {
   const introText = {
@@ -25,7 +32,7 @@ function RoomNarrativeOverlay({ roomName, avatar, onContinue }) {
   return (
     <div className="overlay-bg">
       <div className="overlay-box">
-        {avatar && <div className="overlay-avatar">{avatar}</div>}
+        {avatar && <div className="overlay-avatar">{avatarIcons[avatar]}</div>}
         {lines.map((line, index) => (
           <p key={index}>{line}</p>
         ))}

--- a/src/components/phases/EscapePhase.jsx
+++ b/src/components/phases/EscapePhase.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import ParallaxDust from "../ParallaxDust";
+import "../styles/RoomScene.css";
 
 function EscapePhase({ setGameState, slamBallGoal = 10, squatJumpGoal = 15 }) {
   const [slamBalls, setSlamBalls] = useState(0);
@@ -14,27 +16,31 @@ function EscapePhase({ setGameState, slamBallGoal = 10, squatJumpGoal = 15 }) {
   };
 
   return (
-    <div style={{ padding: 20 }}>
-      <h2>🔧 Escape Options</h2>
-      <p>
-        You finally grab the object—it’s a flathead screwdriver. Not much… but it could help.
-      </p>
-      <p>
-        You check the door: locked. But maybe you can loosen it. Or… there's a bench nearby. Could
-        you climb and escape through the ceiling tiles?
-      </p>
-      <p>🧠 Choose your escape route:</p>
-      <div>
-        <p>💪 Use the screwdriver to jimmy the lock—{slamBallGoal} slam balls</p>
-        <button onClick={() => setSlamBalls(slamBalls + 1)}>Do Slam Ball</button>
-        <p>Progress: {slamBalls}/{slamBallGoal}</p>
+    <div className="room-container">
+      <img src="/Escape_route.png" alt="Possible Escape" className="scene-image" />
+      <ParallaxDust />
+      <div className="room-content rpg-text">
+        <h2>🔧 Escape Options</h2>
+        <p>
+          You finally grab the object—it’s a flathead screwdriver. Not much… but it could help.
+        </p>
+        <p>
+          You check the door: locked. But maybe you can loosen it. Or… there's a bench nearby. Could
+          you climb and escape through the ceiling tiles?
+        </p>
+        <p>🧠 Choose your escape route:</p>
+        <div>
+          <p>💪 Use the screwdriver to jimmy the lock—{slamBallGoal} slam balls</p>
+          <button onClick={() => setSlamBalls(slamBalls + 1)}>Do Slam Ball</button>
+          <p>Progress: {slamBalls}/{slamBallGoal}</p>
+        </div>
+        <div>
+          <p>⚡ Leap onto the bench and push up into the tiles—{squatJumpGoal} squat jumps</p>
+          <button onClick={() => setJumpSquats(jumpSquats + 1)}>Do Squat Jump</button>
+          <p>Progress: {jumpSquats}/{squatJumpGoal}</p>
+        </div>
+        <button onClick={handleBreakOut}>Break Out</button>
       </div>
-      <div>
-        <p>⚡ Leap onto the bench and push up into the tiles—{squatJumpGoal} squat jumps</p>
-        <button onClick={() => setJumpSquats(jumpSquats + 1)}>Do Squat Jump</button>
-        <p>Progress: {jumpSquats}/{squatJumpGoal}</p>
-      </div>
-      <button onClick={handleBreakOut}>Break Out</button>
     </div>
   );
 }

--- a/src/components/phases/MobilityPhase.jsx
+++ b/src/components/phases/MobilityPhase.jsx
@@ -1,4 +1,6 @@
 import React from "react";
+import ParallaxDust from "../ParallaxDust";
+import "../styles/RoomScene.css";
 
 function MobilityPhase({ setGameState }) {
   const handleStretchComplete = () => {
@@ -7,17 +9,21 @@ function MobilityPhase({ setGameState }) {
   };
 
   return (
-    <div style={{ padding: 20 }}>
-      <h2>🧍‍♂️ Mobility Stretch</h2>
-      <p>
-        With your blood flowing, you explore the changing room. A locker lies tipped on its side—
-        underneath it, something shiny glints in the flickering light.
-      </p>
-      <p>
-        You crawl forward… but your body is still stiff from the locker. You can’t quite reach.
-      </p>
-      <p>💪 Perform 10 lunges and 10 arm circles to loosen up.</p>
-      <button onClick={handleStretchComplete}>Stretch Complete</button>
+    <div className="room-container">
+      <img src="/Shiny_Object.png" alt="Shiny Object" className="scene-image" />
+      <ParallaxDust />
+      <div className="room-content rpg-text">
+        <h2>🧍‍♂️ Mobility Stretch</h2>
+        <p>
+          With your blood flowing, you explore the changing room. A locker lies tipped on its side—
+          underneath it, something shiny glints in the flickering light.
+        </p>
+        <p>
+          You crawl forward… but your body is still stiff from the locker. You can’t quite reach.
+        </p>
+        <p>💪 Perform 10 lunges and 10 arm circles to loosen up.</p>
+        <button onClick={handleStretchComplete}>Stretch Complete</button>
+      </div>
     </div>
   );
 }

--- a/src/components/phases/WarmUpPhase.jsx
+++ b/src/components/phases/WarmUpPhase.jsx
@@ -1,17 +1,23 @@
 import React from "react";
+import ParallaxDust from "../ParallaxDust";
+import "../styles/RoomScene.css";
 
 function WarmUpPhase({ setGameState }) {
   return (
-    <div style={{ padding: 20 }}>
-      <h2>🔥 Warm-Up</h2>
-      <p>
-        Your muscles ache. You shuffle across the room, rubbing your arms. You spot a dusty
-        rowing machine still plugged in.
-      </p>
-      <p>🏃 To raise your heart rate, complete a 500m row.</p>
-      <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}>
-        Row Complete
-      </button>
+    <div className="room-container">
+      <img src="/RowingMachine.png" alt="Rowing Machine" className="scene-image" />
+      <ParallaxDust />
+      <div className="room-content rpg-text">
+        <h2>🔥 Warm-Up</h2>
+        <p>
+          Your muscles ache. You shuffle across the room, rubbing your arms. You spot a dusty
+          rowing machine still plugged in.
+        </p>
+        <p>🏃 To raise your heart rate, complete a 500m row.</p>
+        <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}>
+          Row Complete
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/styles/ParallaxDust.css
+++ b/src/components/styles/ParallaxDust.css
@@ -17,19 +17,19 @@
   height: 200%;
   background-image: radial-gradient(rgba(255, 255, 255, 0.3) 1px, transparent 1px);
   background-size: 3px 3px;
-  animation: dust-float 40s linear infinite;
+  animation: dust-float 50s linear infinite;
 }
 
 .dust1 {
-  animation-duration: 40s;
+  animation-duration: 50s;
 }
 
 .dust2 {
-  animation-duration: 55s;
+  animation-duration: 65s;
 }
 
 .dust3 {
-  animation-duration: 70s;
+  animation-duration: 80s;
 }
 
 @keyframes dust-float {


### PR DESCRIPTION
## Summary
- add rower, shiny object, and escape route images
- replace emoji avatars with react-icons
- show avatar icons in overlay
- slow the parallax dust animation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684cac2ad930832fb47f54d5d2978cb9