### PR TITLE
Implement leaderboard view

### DIFF
--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -1,49 +1,91 @@
 import React, { useState } from "react";
-import "./Leaderboard.css"; // Add styles for leaderboard visuals
+import "./styles/Leaderboard.css";
+
+const sampleStats = [
+  { name: "Alice", year: 7, gender: "F", totalWeightMonth: 2200, totalWeightAll: 12000, totalDistanceMonth: 15, totalDistanceAll: 80, bossKillTime: 90 },
+  { name: "Bob", year: 8, gender: "M", totalWeightMonth: 3400, totalWeightAll: 20000, totalDistanceMonth: 25, totalDistanceAll: 140, bossKillTime: 110 },
+  { name: "Charlie", year: 9, gender: "M", totalWeightMonth: 3000, totalWeightAll: 15000, totalDistanceMonth: 20, totalDistanceAll: 120, bossKillTime: 95 },
+  { name: "Daisy", year: 10, gender: "F", totalWeightMonth: 2800, totalWeightAll: 18000, totalDistanceMonth: 30, totalDistanceAll: 200, bossKillTime: 88 },
+  { name: "Evan", year: 11, gender: "M", totalWeightMonth: 4100, totalWeightAll: 22000, totalDistanceMonth: 35, totalDistanceAll: 250, bossKillTime: 80 },
+];
 
 function Leaderboard() {
-  const [leaderboard, setLeaderboard] = useState([
-    { name: "Alice", time: 900 },
-    { name: "Bob", time: 950 },
-    { name: "Charlie", time: 1000 },
-  ]);
-  const [playerName, setPlayerName] = useState("");
-  const [playerTime, setPlayerTime] = useState("");
+  const [year, setYear] = useState("all");
+  const [gender, setGender] = useState("all");
 
-  const addPlayer = () => {
-    const newPlayer = { name: playerName, time: Number(playerTime) };
-    const updatedLeaderboard = [...leaderboard, newPlayer].sort(
-      (a, b) => a.time - b.time
-    );
-    setLeaderboard(updatedLeaderboard.slice(0, 10)); // Keep top 10 players
-    setPlayerName("");
-    setPlayerTime("");
+  const filtered = sampleStats.filter((p) => {
+    const yearMatch = year === "all" || p.year.toString() === year;
+    const genderMatch = gender === "all" || p.gender === gender;
+    return yearMatch && genderMatch;
+  });
+
+  const sortBy = (field, asc = false) => {
+    const sorted = [...filtered].sort((a, b) => {
+      if (asc) return a[field] - b[field];
+      return b[field] - a[field];
+    });
+    return sorted.slice(0, 5);
   };
 
   return (
     <div className="leaderboard-container">
-      <h2>Leaderboard</h2>
-      <ul>
-        {leaderboard.map((player, index) => (
-          <li key={index}>
-            {index + 1}. {player.name} - {player.time}s
-          </li>
-        ))}
-      </ul>
-      <div className="add-player-form">
-        <input
-          type="text"
-          placeholder="Your Name"
-          value={playerName}
-          onChange={(e) => setPlayerName(e.target.value)}
-        />
-        <input
-          type="number"
-          placeholder="Your Time (seconds)"
-          value={playerTime}
-          onChange={(e) => setPlayerTime(e.target.value)}
-        />
-        <button onClick={addPlayer}>Add to Leaderboard</button>
+      <h2>🏅 Fitness Leaderboard</h2>
+      <div className="lb-filters">
+        <select value={year} onChange={(e) => setYear(e.target.value)}>
+          <option value="all">All Years</option>
+          <option value="7">Year 7</option>
+          <option value="8">Year 8</option>
+          <option value="9">Year 9</option>
+          <option value="10">Year 10</option>
+          <option value="11">Year 11</option>
+        </select>
+        <select value={gender} onChange={(e) => setGender(e.target.value)}>
+          <option value="all">All</option>
+          <option value="M">Male</option>
+          <option value="F">Female</option>
+        </select>
+      </div>
+      <div className="lb-grids">
+        <div className="lb-section">
+          <h3>Weight Lifted (Month)</h3>
+          <ol>
+            {sortBy("totalWeightMonth").map((p, i) => (
+              <li key={i}>{p.name} - {p.totalWeightMonth} kg</li>
+            ))}
+          </ol>
+        </div>
+        <div className="lb-section">
+          <h3>Weight Lifted (All Time)</h3>
+          <ol>
+            {sortBy("totalWeightAll").map((p, i) => (
+              <li key={i}>{p.name} - {p.totalWeightAll} kg</li>
+            ))}
+          </ol>
+        </div>
+        <div className="lb-section">
+          <h3>Cardio Distance (Month)</h3>
+          <ol>
+            {sortBy("totalDistanceMonth").map((p, i) => (
+              <li key={i}>{p.name} - {p.totalDistanceMonth} km</li>
+            ))}
+          </ol>
+        </div>
+        <div className="lb-section">
+          <h3>Cardio Distance (All Time)</h3>
+          <ol>
+            {sortBy("totalDistanceAll").map((p, i) => (
+              <li key={i}>{p.name} - {p.totalDistanceAll} km</li>
+            ))}
+          </ol>
+        </div>
+        <div className="lb-section">
+          <h3>Fastest Boss Defeat</h3>
+          <ol>
+            {sortBy("bossKillTime", true).map((p, i) => (
+              <li key={i}>{p.name} - {p.bossKillTime}s</li>
+            ))}
+          </ol>
+        </div>
       </div>
     </div>
   );

--- a/src/components/SignIn.jsx
+++ b/src/components/SignIn.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import "./styles/SignIn.css";
+import Leaderboard from "./Leaderboard";
 
 function SignIn({ onSignIn }) {
   return (
@@ -10,6 +11,7 @@ function SignIn({ onSignIn }) {
         <input placeholder="Password" type="password" />
         <button onClick={onSignIn}>Sign In</button>
       </div>
+      <Leaderboard />
     </div>
   );
 }

--- a/src/components/styles/Leaderboard.css
+++ b/src/components/styles/Leaderboard.css
@@ -1,0 +1,55 @@
+.leaderboard-container {
+  background-image: url('/global-bg.png');
+  background-size: cover;
+  background-position: center;
+  padding: 20px;
+  border-radius: 8px;
+  color: #fff;
+  max-width: 800px;
+  margin: 20px auto;
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.lb-filters {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.lb-filters select {
+  padding: 5px 10px;
+  background: #222;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 4px;
+}
+
+.lb-grids {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 15px;
+}
+
+.lb-section {
+  background: rgba(0, 0, 0, 0.6);
+  padding: 10px;
+  border-radius: 6px;
+}
+
+.lb-section h3 {
+  margin-top: 0;
+  font-size: 16px;
+  text-align: center;
+  color: #a4c639;
+}
+
+.lb-section ol {
+  list-style: decimal inside;
+  padding-left: 0;
+  margin: 0;
+}
+
+.lb-section li {
+  margin: 4px 0;
+}

--- a/src/components/styles/SignIn.css
+++ b/src/components/styles/SignIn.css
@@ -2,10 +2,12 @@
   background-image: url('/global-bg.png');
   background-size: cover;
   background-position: center;
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  padding-bottom: 40px;
 }
 
 .signin-box {
@@ -17,6 +19,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  margin-bottom: 20px;
 }
 
 .signin-box input {


### PR DESCRIPTION
## Summary
- implement new leaderboard component with year and gender filters
- add styling for leaderboard
- display leaderboard on sign-in screen
- adjust sign-in layout

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684cb0621578832f9256fa92be5edc79