### PR TITLE
Improve final boss quiz

### DIFF
--- a/src/components/phases/QuizPhase.jsx
+++ b/src/components/phases/QuizPhase.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from "react";
+import "../styles/Quiz.css";
 
 function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) {
   // Default question pool
@@ -43,6 +44,30 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
         { label: "Gwyn", correct: false },
       ],
     },
+    {
+      q: "Translate 'house' to Spanish.",
+      options: [
+        { label: "Casa", correct: true },
+        { label: "Carro", correct: false },
+        { label: "Mesa", correct: false },
+      ],
+    },
+    {
+      q: "How do you say 'book' in Welsh?",
+      options: [
+        { label: "Llyfr", correct: true },
+        { label: "Cadair", correct: false },
+        { label: "Dwr", correct: false },
+      ],
+    },
+    {
+      q: "What is 'please' in Spanish?",
+      options: [
+        { label: "Por favor", correct: true },
+        { label: "Buenos días", correct: false },
+        { label: "Gracias", correct: false },
+      ],
+    },
   ];
 
   // Build question pool
@@ -59,7 +84,7 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
         ],
       });
     }
-    return pool;
+    return pool.sort(() => Math.random() - 0.5);
   }, [questions, showImpossibleFinal]);
 
   const totalQuestions = questionPool.length;
@@ -68,11 +93,25 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const [correctAnswers, setCorrectAnswers] = useState(0);
   const [quizComplete, setQuizComplete] = useState(false);
+  const [penalty, setPenalty] = useState("");
+
+  const penaltyExercises = [
+    "3 Burpees",
+    "3 Squat Jumps",
+    "3 Star Jumps",
+    "3 Push-ups",
+  ];
 
   // Handle answer click
   const handleAnswer = (option) => {
     const isCorrect = !!option.correct;
-    isCorrect && setCorrectAnswers((c) => c + 1);
+    if (isCorrect) {
+      setCorrectAnswers((c) => c + 1);
+    } else {
+      const random = penaltyExercises[Math.floor(Math.random() * penaltyExercises.length)];
+      setPenalty(`❌ Wrong! Do ${random}!`);
+      setTimeout(() => setPenalty(""), 3000);
+    }
 
     const nextIndex = currentQuestion + 1;
     if (nextIndex < totalQuestions) {
@@ -111,6 +150,7 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
           </button>
         ))}
       </div>
+      {penalty && <p className="penalty-message">{penalty}</p>}
     </div>
   );
 }

--- a/src/components/phases/Room3Boss.jsx
+++ b/src/components/phases/Room3Boss.jsx
@@ -7,7 +7,7 @@ import "../styles/RoomScene.css";
 
 const bossQuizQuestions = [
   {
-    question: "What is the Spanish word for 'yellow'?",
+    q: "What is the Spanish word for 'yellow'?",
     options: [
       { label: "Amarillo", correct: true },
       { label: "Rojo", correct: false },
@@ -16,7 +16,7 @@ const bossQuizQuestions = [
     ],
   },
   {
-    question: "How do you say 'thank you' in Welsh?",
+    q: "How do you say 'thank you' in Welsh?",
     options: [
       { label: "Diolch", correct: true },
       { label: "Croeso", correct: false },
@@ -25,7 +25,7 @@ const bossQuizQuestions = [
     ],
   },
   {
-    question: "Translate 'blue' to Spanish:",
+    q: "Translate 'blue' to Spanish:",
     options: [
       { label: "Azul", correct: true },
       { label: "Negro", correct: false },
@@ -34,7 +34,7 @@ const bossQuizQuestions = [
     ],
   },
   {
-    question: "What does 'nos da' mean in Welsh?",
+    q: "What does 'nos da' mean in Welsh?",
     options: [
       { label: "Good night", correct: true },
       { label: "Good morning", correct: false },
@@ -43,7 +43,7 @@ const bossQuizQuestions = [
     ],
   },
   {
-    question: "How do you say 'dog' in Spanish?",
+    q: "How do you say 'dog' in Spanish?",
     options: [
       { label: "Perro", correct: true },
       { label: "Gato", correct: false },
@@ -52,7 +52,7 @@ const bossQuizQuestions = [
     ],
   },
   {
-    question: "Translate 'Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch' into English:",
+    q: "Translate 'Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch' into English:",
     options: [
       { label: "Yes", correct: false },
       { label: "No", correct: false },

--- a/src/components/styles/Quiz.css
+++ b/src/components/styles/Quiz.css
@@ -1,0 +1,38 @@
+.quiz-container {
+  background: rgba(34, 34, 34, 0.9);
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto;
+  color: #fff;
+}
+
+.quiz-question {
+  font-size: 1.2rem;
+  margin-bottom: 10px;
+}
+
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.quiz-option-btn {
+  padding: 10px 20px;
+  background: #444;
+  color: #fff;
+  border: 1px solid #888;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.quiz-option-btn:hover {
+  background: #666;
+}
+
+.penalty-message {
+  color: #ff9c9c;
+  margin-top: 10px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- fix question text not showing by using `q` key in boss questions
- enhance quiz questions and randomize their order
- show a random short exercise penalty when the player answers incorrectly
- add styling for quiz interface

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0fd79598832fb4388971b414453c