### PR TITLE
Enhance intro visuals and styles

### DIFF
--- a/src/components/MapIntroduction.jsx
+++ b/src/components/MapIntroduction.jsx
@@ -1,4 +1,6 @@
 import React from "react";
+import ParallaxDust from "./ParallaxDust";
+import "./styles/RoomScene.css";
 
 function MapIntroduction({ setGameState }) {
   const handleViewMap = () => {
@@ -15,12 +17,19 @@ function MapIntroduction({ setGameState }) {
   };
 
   return (
-    <div style={{ padding: 20 }}>
-      <h2>🎒 A New Beginning</h2>
-      <p>
-        You step into the dim hallway, breathing heavy after escaping the locker room.
-        Just as you start to gather your bearings, something crunches under your foot.
-      </p>
+    <div className="room-container">
+      <img
+        src="/Leaving_the_LockerRoom.png"
+        alt="Leaving the Locker Room"
+        className="scene-image"
+      />
+      <ParallaxDust />
+      <div className="room-content rpg-text">
+        <h2>🎒 A New Beginning</h2>
+        <p>
+          You step into the dim hallway, breathing heavy after escaping the locker room.
+          Just as you start to gather your bearings, something crunches under your foot.
+        </p>
       <p>
         A torn, dusty <strong>school bag</strong> lies abandoned near the lockers. Its straps are frayed,
         but it feels sturdy enough to carry what you need.
@@ -35,10 +44,11 @@ function MapIntroduction({ setGameState }) {
       <p>
         You sling the bag over your shoulder. From now on, you can collect supplies and keep track of your path.
       </p>
-      <p>
-        Mr. Watkins' room looks slightly ajar. It might be worth investigating first.
-      </p>
-      <button onClick={handleViewMap}>View Map and Begin Exploring</button>
+        <p>
+          Mr. Watkins' room looks slightly ajar. It might be worth investigating first.
+        </p>
+        <button onClick={handleViewMap}>View Map and Begin Exploring</button>
+      </div>
     </div>
   );
 }

--- a/src/components/phases/Room3Boss.jsx
+++ b/src/components/phases/Room3Boss.jsx
@@ -100,7 +100,11 @@ function Room3Boss({ setGameState, gameState }) {
 
   return (
     <div className={`room-container ${((bossPhase === 0 && !workoutLogged) || quizStarted || bossPhase > 0) ? "interaction" : ""}`}>
-      <img src="/Mrs_RochesRoom.png" alt="Mrs. Roche's Room" className="scene-image" />
+      <img
+        src={alarmTriggered && !quizStarted ? "/quiz_door.png" : "/Mrs_RochesRoom.png"}
+        alt="Mrs. Roche's Room"
+        className="scene-image"
+      />
       <ParallaxDust />
       <div className="room-content rpg-text">
         <h1>Mrs. Roche's Classroom</h1>

--- a/src/components/styles/RoomScene.css
+++ b/src/components/styles/RoomScene.css
@@ -19,7 +19,7 @@
   bottom: 0;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: center;
   align-items: center;
   padding: 20px;
   background: rgba(0, 0, 0, 0.4);

--- a/src/index.css
+++ b/src/index.css
@@ -13,14 +13,14 @@ body {
 button {
   padding: 10px 20px;
   font-size: 16px;
-  background-color: #007bff;
+  background-color: #6c757d;
   color: #fff;
   border: none;
   cursor: pointer;
   border-radius: 4px;
 }
 button:hover:not(:disabled) {
-  background-color: #0056b3;
+  background-color: #555;
 }
 
 button:disabled {


### PR DESCRIPTION
## Summary
- display new background when leaving the locker room
- show door image when quiz starts in Roche's room
- center scene narration text
- use gray buttons instead of bright blue

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d1f7a7c18832fba3b1645ca126b58