### PR TITLE
Add door scene images and adjust quiz finale

### DIFF
--- a/src/components/RoomNarrativeOverlay.jsx
+++ b/src/components/RoomNarrativeOverlay.jsx
@@ -27,11 +27,24 @@ function RoomNarrativeOverlay({ roomName, avatar, onContinue }) {
     ],
   };
 
+  const introImages = {
+    "Mr. Watkins' Room": "/Mr_WatkinsDoor.png",
+    "Mrs. John's Room": "/Mrs_JohnsDoor.png",
+    "Mrs. Roche's Room": "/Mrs_RochesDoor.png",
+  };
+
   const lines = introText[roomName] || ["You enter the room…"];
 
   return (
     <div className="overlay-bg">
       <div className="overlay-box">
+        {introImages[roomName] && (
+          <img
+            src={introImages[roomName]}
+            alt={roomName}
+            className="overlay-image"
+          />
+        )}
         {avatar && <div className="overlay-avatar">{avatarIcons[avatar]}</div>}
         {lines.map((line, index) => (
           <p key={index}>{line}</p>

--- a/src/components/phases/QuizPhase.jsx
+++ b/src/components/phases/QuizPhase.jsx
@@ -72,9 +72,10 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
 
   // Build question pool
   const questionPool = useMemo(() => {
-    const pool = Array.isArray(questions) && questions.length > 0 ? [...questions] : [...defaultPool];
+    let pool = Array.isArray(questions) && questions.length > 0 ? [...questions] : [...defaultPool];
+    let finalQ = null;
     if (showImpossibleFinal) {
-      pool.push({
+      finalQ = {
         q: "Translate 'Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch' into English:",
         options: [
           { label: "Yes", correct: false },
@@ -82,9 +83,11 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
           { label: "What did you just say?", correct: false },
           { label: "I give up", correct: false },
         ],
-      });
+      };
     }
-    return pool.sort(() => Math.random() - 0.5);
+    pool = pool.sort(() => Math.random() - 0.5);
+    if (finalQ) pool.push(finalQ);
+    return pool;
   }, [questions, showImpossibleFinal]);
 
   const totalQuestions = questionPool.length;
@@ -94,6 +97,7 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
   const [correctAnswers, setCorrectAnswers] = useState(0);
   const [quizComplete, setQuizComplete] = useState(false);
   const [penalty, setPenalty] = useState("");
+  const [finalWrong, setFinalWrong] = useState(false);
 
   const penaltyExercises = [
     "3 Burpees",
@@ -105,8 +109,13 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
   // Handle answer click
   const handleAnswer = (option) => {
     const isCorrect = !!option.correct;
+    const isLast = currentQuestion === totalQuestions - 1;
+
     if (isCorrect) {
       setCorrectAnswers((c) => c + 1);
+    } else if (showImpossibleFinal && isLast) {
+      setFinalWrong(true);
+      setPenalty("");
     } else {
       const random = penaltyExercises[Math.floor(Math.random() * penaltyExercises.length)];
       setPenalty(`❌ Wrong! Do ${random}!`);
@@ -127,6 +136,12 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
       <div className="quiz-container">
         <h2>🎉 Quiz Complete</h2>
         <p>You answered {correctAnswers} out of {totalQuestions} correctly.</p>
+        {finalWrong && (
+          <p>
+            A mutated figure charges at you! You dive aside as it smashes the
+            door open.
+          </p>
+        )}
         <button onClick={() => onComplete(correctAnswers)}>Continue</button>
       </div>
     );

--- a/src/components/styles/Overlay.css
+++ b/src/components/styles/Overlay.css
@@ -23,3 +23,9 @@
   font-size: 3rem;
   margin-bottom: 10px;
 }
+
+.overlay-image {
+  width: 100%;
+  border-radius: 8px;
+  margin-bottom: 15px;
+}


### PR DESCRIPTION
## Summary
- show door images in room transition overlays
- tweak overlay styles for new images
- make impossible question always last in quiz and remove penalty when it's wrong
- show mutated figure narrative if final question wrong

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d2a56b434832f81779354a6b4646c