### PR TITLE
Improve badge styling and show safe image

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -71,7 +71,9 @@ function Map({ gameState, setGameState }) {
       <p className="map-instructions">
         🔍 Click on any visible room to investigate. Rooms will reveal themselves as you explore!
       </p>
-      <button onClick={() => setShowBadges(true)}>View Badges</button>
+      <button className="badge-button" onClick={() => setShowBadges(true)}>
+        View Badges
+      </button>
       {showBadges && (
         <BadgeCase badges={gameState.badges} onClose={() => setShowBadges(false)} />
       )}

--- a/src/components/events/SafeQuizEvent.jsx
+++ b/src/components/events/SafeQuizEvent.jsx
@@ -1,4 +1,7 @@
 import React, { useState } from "react";
+import "../styles/SafeQuizEvent.css";
+
+const baseUrl = import.meta.env.BASE_URL || "/";
 
 const SafeQuizEvent = ({ questionPool, onSuccess, onFailure, roomName }) => {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
@@ -45,6 +48,7 @@ const SafeQuizEvent = ({ questionPool, onSuccess, onFailure, roomName }) => {
 
   return (
     <div className="safe-event">
+      <img src={`${baseUrl}safe.png`} alt="Digital Safe" className="safe-image" />
       <h2>🔐 Digital Safe - {roomName}</h2>
       <p><strong>Lives:</strong> {"❤️".repeat(lives)} {"🤍".repeat(3 - lives)}</p>
       <p>{currentQuestion?.question}</p>

--- a/src/components/styles/BadgeCase.css
+++ b/src/components/styles/BadgeCase.css
@@ -12,18 +12,26 @@
 }
 
 .badge-case {
-  background: #fff;
-  padding: 20px;
-  max-width: 300px;
+  background: #f5f5dc;
+  padding: 30px;
+  max-width: 400px;
   border-radius: 8px;
   text-align: center;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  font-family: "Papyrus", fantasy;
+}
+
+.badge-case ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 10px;
 }
 
 .badge-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
+  gap: 10px;
+  margin-bottom: 8px;
 }
 
 .badge-item .icon {
@@ -31,7 +39,16 @@
 }
 
 .badge-img {
-  width: 32px;
-  height: 32px;
+  width: 48px;
+  height: 48px;
   object-fit: contain;
+}
+
+.badge-item .label {
+  font-weight: bold;
+}
+
+.badge-item .desc {
+  font-size: 0.9em;
+  color: #333;
 }

--- a/src/components/styles/Map.css
+++ b/src/components/styles/Map.css
@@ -105,3 +105,9 @@
   font-size: 14px;
   font-style: italic;
 }
+
+.badge-button {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+}

--- a/src/components/styles/SafeQuizEvent.css
+++ b/src/components/styles/SafeQuizEvent.css
@@ -1,0 +1,13 @@
+.safe-event {
+  background: rgba(0, 0, 0, 0.8);
+  padding: 20px;
+  border-radius: 8px;
+  color: #fff;
+  text-align: center;
+}
+
+.safe-image {
+  width: 200px;
+  margin: 0 auto 15px;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- display a safe image at the beginning of SafeQuizEvent
- restyle BadgeCase with larger icons and fantasy font
- reposition View Badges button on the map
- support SafeQuizEvent styles

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d88cb9850832fa85debfbae302865