### PR TITLE
Implement global enhanced reading and update quiz logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ To create a production build, run `npm run build` and serve the resulting `dist`
 ## Accessibility
 
 The character creation screen includes an **Enhanced Reading Mode** toggle for
-users with dyslexia or vision impairments. When enabled, the interface uses
-a higher contrast background and larger fonts to improve readability.
+users with dyslexia or vision impairments. When enabled, the entire game uses
+a higher contrast background and larger fonts to improve readability, including
+all narration and workout cards.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -114,7 +114,7 @@ function App() {
   };
 
   return (
-    <div>
+    <div className={gameState.enhancedReading ? "enhanced-reading" : ""}>
       {signedIn && gameState.characterCreated && (
         <XPBar
           avatar={gameState.avatar}

--- a/src/components/phases/QuizPhase.jsx
+++ b/src/components/phases/QuizPhase.jsx
@@ -70,12 +70,56 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
     },
   ];
 
+  const extraPool = [
+    {
+      q: "How do you say 'hello' in Welsh?",
+      options: [
+        { label: "Helo", correct: true },
+        { label: "Diolch", correct: false },
+        { label: "Hwyl", correct: false },
+      ],
+    },
+    {
+      q: "Translate 'school' to Welsh.",
+      options: [
+        { label: "Ysgol", correct: true },
+        { label: "Ty", correct: false },
+        { label: "Bws", correct: false },
+      ],
+    },
+    {
+      q: "What is 'red' in Spanish?",
+      options: [
+        { label: "Rojo", correct: true },
+        { label: "Negro", correct: false },
+        { label: "Verde", correct: false },
+      ],
+    },
+    {
+      q: "How do you say 'goodbye' in Welsh?",
+      options: [
+        { label: "Hwyl fawr", correct: true },
+        { label: "Nos da", correct: false },
+        { label: "Croeso", correct: false },
+      ],
+    },
+  ];
+
   // Build question pool
   const questionPool = useMemo(() => {
     let pool = Array.isArray(questions) && questions.length > 0 ? [...questions] : [...defaultPool];
-    let finalQ = null;
+    pool = pool.sort(() => Math.random() - 0.5);
+
+    // ensure at least 6 questions before the final one
+    let extraIndex = 0;
+    while (pool.length < 6) {
+      pool.push(extraPool[extraIndex % extraPool.length]);
+      extraIndex += 1;
+    }
+    pool = pool.slice(0, 6);
+
     if (showImpossibleFinal) {
-      finalQ = {
+      const finalQ = {
         q: "Translate 'Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch' into English:",
         options: [
           { label: "Yes", correct: false },
@@ -84,9 +128,9 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
           { label: "I give up", correct: false },
         ],
       };
+      pool.push(finalQ);
     }
-    pool = pool.sort(() => Math.random() - 0.5);
-    if (finalQ) pool.push(finalQ);
+
     return pool;
   }, [questions, showImpossibleFinal]);
 

--- a/src/components/phases/Room3Boss.jsx
+++ b/src/components/phases/Room3Boss.jsx
@@ -53,12 +53,12 @@ const bossQuizQuestions = [
     ],
   },
   {
-    q: "Translate 'Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch' into English:",
+    q: "What is the Welsh word for 'school'?",
     options: [
-      { label: "Yes", correct: false },
-      { label: "No", correct: false },
-      { label: "What did you just say?", correct: false },
-      { label: "I give up", correct: false },
+      { label: "Ysgol", correct: true },
+      { label: "Cartref", correct: false },
+      { label: "Bws", correct: false },
+      { label: "Cwch", correct: false },
     ],
   },
 ];
@@ -155,13 +155,8 @@ function Room3Boss({ setGameState, gameState }) {
         <>
           <h2>👹 Mutated Mrs. Roche uses Ground Stomp!</h2>
           <p>You must jump onto the desk to avoid the shockwave.</p>
-          <p><strong>Complete 15 Burpee Box Jumps</strong> to survive.</p>
-          <WorkoutLogger
-            roomNumber={3}
-            setGameState={setGameState}
-            workoutFocus={gameState.workoutFocus}
-          />
-          <button onClick={handlePhaseOneComplete}>I Logged My Burpee Box Jumps</button>
+          <p><strong>Perform 15 Burpee Box Jumps</strong> to survive.</p>
+          <button onClick={handlePhaseOneComplete}>I've done that</button>
         </>
       )}
 
@@ -169,13 +164,8 @@ function Room3Boss({ setGameState, gameState }) {
         <>
           <h2>🐉 Roche spins violently with a Whipping Spiral!</h2>
           <p>You must laterally leap to avoid the tail — or risk being slammed against the walls.</p>
-          <p><strong>Complete 20 Lateral Bunny Hops over the Free Weight Bench</strong> to dodge.</p>
-          <WorkoutLogger
-            roomNumber={3}
-            setGameState={setGameState}
-            workoutFocus={gameState.workoutFocus}
-          />
-          <button onClick={handlePhaseTwoComplete}>Run for the door!</button>
+          <p><strong>Perform 20 Lateral Bunny Hops over the Free Weight Bench</strong> to dodge.</p>
+          <button onClick={handlePhaseTwoComplete}>I've done that</button>
         </>
       )}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -28,3 +28,13 @@ button:disabled {
   cursor: not-allowed;
 }
 
+.enhanced-reading {
+  background-color: #fffae5;
+  color: #000;
+  font-size: 1.1rem;
+}
+
+.enhanced-reading .rpg-text {
+  font-size: 1.2rem;
+}
+


### PR DESCRIPTION
## Summary
- enable enhanced reading mode across the entire game
- add global styles for enhanced reading
- tweak README to mention full-game support
- expand quiz question pool and ensure Llanfairpwll question is 7th
- adjust Room 3 boss scenes to skip workout logger

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dde57e178832f9fb296d4821c9529