### PR TITLE
Add simple TTS via eSpeak

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ This project can play voice over audio generated with [Bark](https://github.com/
 
 3. Place the generated files in `public/voices` and the game will play them during key scenes.
 
+### Alternative lightweight TTS with eSpeak
+
+If you prefer a smaller solution without downloading the large Bark models, you
+can generate voices using [eSpeak](https://espeak.sourceforge.net/).
+
+1. Install eSpeak:
+
+   ```bash
+   sudo apt-get install espeak
+   ```
+
+2. Run the provided `generate_espeak_voice.py` script:
+
+   ```bash
+   python generate_espeak_voice.py "Your text here" public/voices/your-file.wav
+   ```
+
+The generated `.wav` file can be placed in `public/voices` just like Bark audio
+files.
+
 ## Accessibility
 
 The character creation screen includes an **Enhanced Reading Mode** toggle for

--- a/generate_espeak_voice.py
+++ b/generate_espeak_voice.py
@@ -1,0 +1,24 @@
+import sys
+import subprocess
+from pathlib import Path
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: python generate_espeak_voice.py 'text to speak' output.wav")
+        sys.exit(1)
+
+    text = sys.argv[1]
+    out_path = Path(sys.argv[2])
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        subprocess.run(['espeak', text, '-w', str(out_path)], check=True)
+        print(f"Saved voice over to {out_path}")
+    except FileNotFoundError:
+        print('espeak is required. Install it with:\n  apt-get install espeak')
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a small Python script `generate_espeak_voice.py` that uses eSpeak to synthesize text
- document eSpeak usage as a lighter alternative for generating voiceovers in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f26ccfad8832fb2136962a50ba50a