### PR TITLE
Allow custom preset when generating Tortoise TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ If you have a GPU available you can generate more natural voices using [Tortoise
 2. Run the provided `generate_tortoise_voice.py` script:
 
    ```bash
-   python generate_tortoise_voice.py "Your text here" public/voices/your-file.wav [voice-name]
+   python generate_tortoise_voice.py "Your text here" public/voices/your-file.wav [voice-name] [preset]
    ```
 
-   The optional `voice-name` argument selects one of the bundled voices (defaults to `random`).
+   `voice-name` selects one of the bundled voices (defaults to `random`).
+   The optional `preset` argument controls quality (`fast`, `standard`, `high_quality`).
 
 ## Accessibility
 

--- a/generate_tortoise_voice.py
+++ b/generate_tortoise_voice.py
@@ -12,18 +12,19 @@ except ImportError:
 
 def main():
     if len(sys.argv) < 3:
-        print("Usage: python generate_tortoise_voice.py 'text to speak' output.wav [voice]")
+        print("Usage: python generate_tortoise_voice.py 'text to speak' output.wav [voice] [preset]")
         sys.exit(1)
 
     text = sys.argv[1]
     out_path = Path(sys.argv[2])
     voice = sys.argv[3] if len(sys.argv) > 3 else 'random'
+    preset = sys.argv[4] if len(sys.argv) > 4 else 'high_quality'
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     tts = TextToSpeech()
     voice_samples, conditioning_latents = load_voices([voice])
     print("Generating audio... this may take a while")
-    audio = tts.tts_with_preset(text, voice_samples=voice_samples, conditioning_latents=conditioning_latents, preset='fast')
+    audio = tts.tts_with_preset(text, voice_samples=voice_samples, conditioning_latents=conditioning_latents, preset=preset)
     if isinstance(audio, list):
         audio = audio[0]
     torchaudio.save(str(out_path), audio.squeeze(0).cpu(), 24000)


### PR DESCRIPTION
## Summary
- support an optional quality preset in `generate_tortoise_voice.py`
- document the new argument in the README

## Testing
- `pip install torchaudio`
- `python generate_tortoise_voice.py "You were stuffed..." public/voices/intro-phase.wav daniel`
  - fails: ProxyError to huggingface

------
https://chatgpt.com/codex/tasks/task_e_684f2c4e63bc832fb91128c37b3dcf1e