### PR TITLE
Add basic text to speech toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,8 @@ The character creation screen includes an **Enhanced Reading Mode** toggle for
 users with dyslexia or vision impairments. When enabled, the entire game uses
 a higher contrast background and larger fonts to improve readability, including
 all narration and workout cards.
+
+The same screen now also offers a **Text to Speech** toggle. When enabled,
+game narration and instructions are automatically read aloud using your
+browser's built‑in speech synthesis (eSpeak on many systems). This helps
+players who struggle with reading or who are visually impaired.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import SignIn from "./components/SignIn";
 import CharacterCreation from "./components/CharacterCreation";
 import IntroPhase from "./components/phases/IntroPhase";
@@ -15,7 +15,7 @@ import VictoryPhase from "./components/phases/VictoryPhase";
 import RoomNarrativeOverlay from "./components/RoomNarrativeOverlay";
 import FinalBossPhase from "./components/phases/FinalBossPhase";
 import XPBar from "./components/XPBar";
-import { playSound } from "./utils";
+import { playSound, speakText } from "./utils";
 
 function App() {
   const [signedIn, setSignedIn] = useState(false);
@@ -43,7 +43,15 @@ function App() {
     victory: false,
     showOverlay: true,
     enhancedReading: false,
+    textToSpeech: false,
   });
+
+  useEffect(() => {
+    if (gameState.textToSpeech) {
+      const el = document.querySelector('.rpg-text');
+      if (el) speakText(el.innerText);
+    }
+  }, [gameState.textToSpeech, gameState.introStage, gameState.currentRoom, gameState.showOverlay, signedIn]);
 
   const renderPhase = () => {
     if (!signedIn) return <SignIn onSignIn={() => setSignedIn(true)} />;

--- a/src/components/CharacterCreation.jsx
+++ b/src/components/CharacterCreation.jsx
@@ -81,6 +81,19 @@ function CharacterCreation({ gameState, setGameState }) {
           />
           Enhanced Reading Mode
         </label>
+        <label className="tts-toggle">
+          <input
+            type="checkbox"
+            checked={gameState.textToSpeech || false}
+            onChange={(e) =>
+              setGameState({
+                ...gameState,
+                textToSpeech: e.target.checked,
+              })
+            }
+          />
+          Text to Speech
+        </label>
         <button onClick={() => setGameState({ ...gameState, characterCreated: true })}>
           Start Game
         </button>

--- a/src/components/styles/CharacterCreation.css
+++ b/src/components/styles/CharacterCreation.css
@@ -61,3 +61,10 @@
   gap: 5px;
   justify-content: center;
 }
+
+.tts-toggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  justify-content: center;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,3 +14,11 @@ export function playVoice(filePath) {
   audio.volume = 1.0;
   audio.play().catch(() => {});
 }
+
+// Speak the provided text using the browser's speech synthesis API
+export function speakText(text) {
+  if (typeof window === 'undefined' || !window.speechSynthesis) return;
+  const utterance = new SpeechSynthesisUtterance(text);
+  window.speechSynthesis.cancel();
+  window.speechSynthesis.speak(utterance);
+}


### PR DESCRIPTION
## Summary
- introduce simple `speakText` helper using SpeechSynthesis
- wire up new `textToSpeech` option in game state
- expose toggle on the character creation screen
- read current scene aloud when text to speech is enabled
- mention accessibility option in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f36f9a6c8832f8a499591d545d420