### PR TITLE
Integrate Google TTS with visual aid toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ a higher contrast background and larger fonts to improve readability, including
 all narration and workout cards.
 
 The same screen now also offers a **Text to Speech** toggle. When enabled,
-game narration and instructions are automatically read aloud using your
-browser's built‑in speech synthesis (eSpeak on many systems). This helps
-players who struggle with reading or who are visually impaired.
+game narration and instructions are automatically read aloud using Google's
+Text-to-Speech API. Set the `VITE_GOOGLE_TTS_KEY` environment variable with
+your API key when running the app. The voice defaults to a male British
+accent at a slower rate, providing a clear, serious delivery for players who
+struggle with reading or who are visually impaired.

--- a/src/components/CharacterCreation.jsx
+++ b/src/components/CharacterCreation.jsx
@@ -72,12 +72,14 @@ function CharacterCreation({ gameState, setGameState }) {
           <input
             type="checkbox"
             checked={gameState.enhancedReading || false}
-            onChange={(e) =>
+            onChange={(e) => {
+              const checked = e.target.checked;
               setGameState({
                 ...gameState,
-                enhancedReading: e.target.checked,
-              })
-            }
+                enhancedReading: checked,
+                textToSpeech: checked,
+              });
+            }}
           />
           Enhanced Reading Mode
         </label>

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,9 +16,36 @@ export function playVoice(filePath) {
 }
 
 // Speak the provided text using the browser's speech synthesis API
-export function speakText(text) {
-  if (typeof window === 'undefined' || !window.speechSynthesis) return;
-  const utterance = new SpeechSynthesisUtterance(text);
-  window.speechSynthesis.cancel();
-  window.speechSynthesis.speak(utterance);
+
+// Speak the provided text using Google Text-to-Speech REST API
+// Requires VITE_GOOGLE_TTS_KEY environment variable containing an API key
+export async function speakText(text) {
+  if (typeof fetch === 'undefined') return;
+  try {
+    const apiKey = import.meta.env.VITE_GOOGLE_TTS_KEY;
+    const response = await fetch(
+      `https://texttospeech.googleapis.com/v1/text:synthesize?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          input: { text },
+          voice: {
+            languageCode: 'en-GB',
+            name: 'en-GB-Wavenet-B',
+            ssmlGender: 'MALE',
+          },
+          audioConfig: { audioEncoding: 'MP3', speakingRate: 0.8 },
+        }),
+      }
+    );
+
+    const data = await response.json();
+    if (data.audioContent) {
+      const audio = new Audio(`data:audio/mp3;base64,${data.audioContent}`);
+      audio.play().catch(() => {});
+    }
+  } catch (err) {
+    console.error('Failed to speak text with Google TTS', err);
+  }
 }


### PR DESCRIPTION
## Summary
- add Google Text-to-Speech REST usage
- auto-enable TTS when Enhanced Reading Mode is toggled
- document Google TTS and API key requirement

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f42c46f68832f9ef14081fef8599f