### PR TITLE
Improve TTS fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ all narration and workout cards.
 The same screen now also offers a **Text to Speech** toggle. When enabled,
 game narration and instructions are automatically read aloud using Google's
 Text-to-Speech API. Set the `VITE_GOOGLE_TTS_KEY` environment variable with
-your API key when running the app. The voice defaults to a male British
-accent at a slower rate, providing a clear, serious delivery for players who
-struggle with reading or who are visually impaired.
+your API key when running the app. If no key is provided or the request fails,
+the app will fall back to the browser's built-in `speechSynthesis` if
+available. The voice defaults to a male British accent at a slower rate,
+providing a clear, serious delivery for players who struggle with reading or
+who are visually impaired.

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,14 +49,22 @@ export function playVoice(filePath) {
   audio.play().catch(() => {});
 }
 
-// Speak the provided text using the browser's speech synthesis API
-
 // Speak the provided text using Google Text-to-Speech REST API
 // Requires VITE_GOOGLE_TTS_KEY environment variable containing an API key
 export async function speakText(text) {
   if (typeof fetch === 'undefined') return;
+  const apiKey = import.meta.env.VITE_GOOGLE_TTS_KEY;
+  if (!apiKey) {
+    if ('speechSynthesis' in window) {
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.lang = 'en-GB';
+      utterance.rate = 0.8;
+      window.speechSynthesis.speak(utterance);
+    }
+    return;
+  }
+
   try {
-    const apiKey = import.meta.env.VITE_GOOGLE_TTS_KEY;
     const response = await fetch(
       `https://texttospeech.googleapis.com/v1/text:synthesize?key=${apiKey}`,
       {
@@ -81,5 +89,11 @@ export async function speakText(text) {
     }
   } catch (err) {
     console.error('Failed to speak text with Google TTS', err);
+    if ('speechSynthesis' in window) {
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.lang = 'en-GB';
+      utterance.rate = 0.8;
+      window.speechSynthesis.speak(utterance);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add speechSynthesis fallback when Google TTS key is missing
- document the fallback in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f4ce81cdc832fadfe6609d827b59d