### PR TITLE
Improve sound integration

### DIFF
--- a/src/components/MapIntroduction.jsx
+++ b/src/components/MapIntroduction.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ParallaxDust from "./ParallaxDust";
 import "./styles/RoomScene.css";
+import { playSound } from "../utils";
 
 function MapIntroduction({ setGameState }) {
   const handleViewMap = () => {
@@ -14,6 +15,7 @@ function MapIntroduction({ setGameState }) {
       introStage: 5, // Transition to map view stage
       visibleRooms: [...prev.visibleRooms, "Mr. Watkins' Room"], // Safely add "Mr. Watkins' Room"
     }));
+    playSound();
   };
 
   return (

--- a/src/components/phases/EscapePhase.jsx
+++ b/src/components/phases/EscapePhase.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
+import { playSound } from "../../utils";
 
 function EscapePhase({ setGameState, slamBallGoal = 10, squatJumpGoal = 15 }) {
   const [slamBalls, setSlamBalls] = useState(0);
@@ -16,6 +17,7 @@ function EscapePhase({ setGameState, slamBallGoal = 10, squatJumpGoal = 15 }) {
           ? prev.badges
           : [...prev.badges, "lockerEscapee"],
       }));
+      playSound('openingDoor');
     } else {
       alert("Complete the required exercises to escape!");
     }

--- a/src/components/phases/IntroPhase.jsx
+++ b/src/components/phases/IntroPhase.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
-import { playVoice } from "../../utils";
+import { playVoice, playSound } from "../../utils";
 
 function IntroPhase({ setGameState }) {
   useEffect(() => {
@@ -28,7 +28,10 @@ function IntroPhase({ setGameState }) {
           You collapse out onto the changing room floor, freezing cold.
         </p>
         <p>You must get warm fast or risk freezing in the dark...</p>
-        <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 1 }))}>
+        <button onClick={() => {
+          playSound('footsteps');
+          setGameState((prev) => ({ ...prev, introStage: 1 }));
+        }}>
           Get Moving
         </button>
       </div>

--- a/src/components/phases/MobilityPhase.jsx
+++ b/src/components/phases/MobilityPhase.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
+import { playSound } from "../../utils";
 
 function MobilityPhase({ setGameState }) {
   const handleStretchComplete = () => {
     // Transition to escape phase after completing stretches
     setGameState((prev) => ({ ...prev, introStage: 3 })); // Move to escape phase
+    playSound();
   };
 
   return (

--- a/src/components/phases/VictoryPhase.jsx
+++ b/src/components/phases/VictoryPhase.jsx
@@ -1,6 +1,10 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { playSound } from "../../utils";
 
 function VictoryPhase({ gameState }) {
+  useEffect(() => {
+    playSound('xpLevel');
+  }, []);
   return (
     <div style={{ padding: 20 }}>
       <h2>🎉 Victory!</h2>


### PR DESCRIPTION
## Summary
- play pickup sound after picking up map
- make mobility stretch completion play a sound
- trigger door opening sound once you escape
- play footsteps after intro dialog
- celebrate victory with XP level up jingle

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f4ffa4430832f9c819a32b7982790