### PR TITLE
Add cardio exercise options

### DIFF
--- a/src/components/WorkoutLogger.jsx
+++ b/src/components/WorkoutLogger.jsx
@@ -1,11 +1,12 @@
 import React, { useState } from "react";
 import { playSound } from "../utils";
+import cardioExercises from "../data/cardioExercises";
 
 function WorkoutLogger({ roomNumber, setGameState, workoutFocus }) {
   const cardioMode = workoutFocus === "cardio";
   const [exerciseInput, setExerciseInput] = useState(
     cardioMode
-      ? { name: "", duration: "", distance: "" }
+      ? { name: cardioExercises[0].name, duration: "", distance: "" }
       : { name: "", sets: "", reps: "", weight: "" }
   );
   const [workoutLog, setWorkoutLog] = useState([]);
@@ -14,7 +15,7 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus }) {
     if (cardioMode) {
       if (exerciseInput.name && exerciseInput.duration && exerciseInput.distance) {
         setWorkoutLog([...workoutLog, exerciseInput]);
-        setExerciseInput({ name: "", duration: "", distance: "" });
+        setExerciseInput({ name: cardioExercises[0].name, duration: "", distance: "" });
       }
     } else {
       if (exerciseInput.name && exerciseInput.sets && exerciseInput.reps && exerciseInput.weight) {
@@ -44,15 +45,20 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus }) {
   return (
     <div>
       <h3>Log Your Workout (Room {roomNumber})</h3>
-      <input
-        placeholder="Exercise Name"
-        value={exerciseInput.name}
-        onChange={(e) =>
-          setExerciseInput({ ...exerciseInput, name: e.target.value })
-        }
-      />
       {cardioMode ? (
         <>
+          <select
+            value={exerciseInput.name}
+            onChange={(e) =>
+              setExerciseInput({ ...exerciseInput, name: e.target.value })
+            }
+          >
+            {cardioExercises.map((ex) => (
+              <option key={ex.name} value={ex.name}>
+                {ex.name}
+              </option>
+            ))}
+          </select>
           <input
             placeholder="Duration (min)"
             value={exerciseInput.duration}
@@ -70,6 +76,13 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus }) {
         </>
       ) : (
         <>
+          <input
+            placeholder="Exercise Name"
+            value={exerciseInput.name}
+            onChange={(e) =>
+              setExerciseInput({ ...exerciseInput, name: e.target.value })
+            }
+          />
           <input
             placeholder="Sets"
             value={exerciseInput.sets}

--- a/src/data/cardioExercises.js
+++ b/src/data/cardioExercises.js
@@ -1,0 +1,46 @@
+const cardioExercises = [
+  {
+    name: "Treadmill Run",
+    category: "Cardio",
+    type: "Cardio",
+    equipment: "Treadmill",
+  },
+  {
+    name: "Treadmill Walk",
+    category: "Cardio",
+    type: "Cardio",
+    equipment: "Treadmill",
+  },
+  {
+    name: "Air Bike",
+    category: "Cardio",
+    type: "Cardio",
+    equipment: "Assault Bike / Air Bike",
+  },
+  {
+    name: "Upright Cycle",
+    category: "Cardio",
+    type: "Cardio",
+    equipment: "Stationary Bike",
+  },
+  {
+    name: "Rowing Machine (500m)",
+    category: "Cardio",
+    type: "Cardio",
+    equipment: "Rower",
+  },
+  {
+    name: "SkiErg (Calories or Distance)",
+    category: "Cardio",
+    type: "Cardio",
+    equipment: "SkiErg",
+  },
+  {
+    name: "Skipping (Calories or Distance)",
+    category: "Cardio",
+    type: "Cardio",
+    equipment: "Skipping Rope",
+  },
+];
+
+export default cardioExercises;


### PR DESCRIPTION
## Summary
- add a cardio exercise dataset
- show dropdown of cardio options when logging cardio workouts

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ff2abfba0832f85b0bde2e308c26b