### PR TITLE
Add summary UI components

### DIFF
--- a/src/components/LifetimeSummaryPanel.jsx
+++ b/src/components/LifetimeSummaryPanel.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+  IoBarbell,
+  IoWalk,
+  IoFlame,
+  IoTrophy,
+  IoShirt,
+  IoCheckmarkCircle,
+} from "react-icons/io5";
+import "./styles/LifetimeSummary.css";
+
+function LifetimeSummaryPanel({ username, summary }) {
+  if (!summary) return null;
+  const {
+    workouts,
+    weightLifted,
+    distance,
+    calories,
+    bossesDefeated,
+    cosmetics,
+  } = summary;
+
+  return (
+    <div className="lifetime-panel">
+      <h2 className="lifetime-header">Welcome back, {username}!</h2>
+      <p className="lifetime-subheader">Your progress so far:</p>
+      <ul className="lifetime-stats">
+        <li><IoCheckmarkCircle /> <span>Workouts Completed:</span> <strong>{workouts}</strong></li>
+        <li><IoBarbell /> <span>Total Weight Lifted:</span> <strong>{weightLifted}</strong></li>
+        <li><IoWalk /> <span>Distance Travelled:</span> <strong>{distance}</strong></li>
+        <li><IoFlame /> <span>Total Calories Burned:</span> <strong>{calories}</strong></li>
+        <li><IoTrophy /> <span>Bosses Defeated:</span> <strong>{bossesDefeated}</strong></li>
+        <li><IoShirt /> <span>Cosmetics Unlocked:</span> <strong>{cosmetics}</strong></li>
+      </ul>
+    </div>
+  );
+}
+
+export default LifetimeSummaryPanel;

--- a/src/components/SessionSummaryModal.jsx
+++ b/src/components/SessionSummaryModal.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { IoBarbell, IoWalk, IoFlame, IoBook } from "react-icons/io5";
+import "./styles/SessionSummary.css";
+
+function SessionSummaryModal({ summary, onContinue, onViewLog }) {
+  if (!summary) return null;
+  const { totalWeight, distance, calories, exerciseCount } = summary;
+  return (
+    <div className="session-summary-overlay">
+      <div className="session-summary-box">
+        <h2 className="session-summary-header">SESSION COMPLETE</h2>
+        <ul className="summary-list">
+          <li><IoBarbell /> <span>Total Weight Lifted:</span> <strong>{totalWeight}</strong></li>
+          <li><IoWalk /> <span>Distance Travelled:</span> <strong>{distance}</strong></li>
+          <li><IoFlame /> <span>Estimated Calories Burned:</span> <strong>{calories}</strong></li>
+          <li><IoBook /> <span>Exercises Logged:</span> <strong>{exerciseCount}</strong></li>
+        </ul>
+        <div className="session-summary-actions">
+          {onViewLog && (
+            <button className="log-btn" onClick={onViewLog}>View My Logbook</button>
+          )}
+          <button className="continue-btn" onClick={onContinue}>Continue</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SessionSummaryModal;

--- a/src/components/WorkoutLogger.jsx
+++ b/src/components/WorkoutLogger.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { playSound } from "../utils";
+import SessionSummaryModal from "./SessionSummaryModal";
 import exerciseList from "../data/exerciseList";
 import cardioExercises from "../data/cardioExercises";
 import "./styles/WorkoutLogger.css";
@@ -16,6 +17,8 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus }) {
       : { name: "", sets: "", reps: "", weight: "" }
   );
   const [workoutLog, setWorkoutLog] = useState([]);
+  const [showSummary, setShowSummary] = useState(false);
+  const [summaryData, setSummaryData] = useState(null);
 
   const handleAddExercise = () => {
     if (cardioMode) {
@@ -35,6 +38,21 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus }) {
   };
 
   const handleFinishWorkout = () => {
+    const totalWeight = workoutLog.reduce(
+      (sum, w) => sum + ((parseFloat(w.sets) || 0) * (parseFloat(w.reps) || 0) * (parseFloat(w.weight) || 0)),
+      0
+    );
+    const distance = workoutLog.reduce((sum, w) => sum + (parseFloat(w.distance) || 0), 0);
+    const calories = Math.round(distance * 60 + totalWeight * 0.1);
+
+    setSummaryData({
+      totalWeight: `${totalWeight.toFixed(1)} kg`,
+      distance: `${distance.toFixed(1)} km`,
+      calories: `${calories} kcal`,
+      exerciseCount: workoutLog.length,
+    });
+    setShowSummary(true);
+
     setGameState((prev) => ({
       ...prev,
       xp: (prev.xp || 0) + 10,
@@ -135,6 +153,12 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus }) {
       <button className="primary-btn finish-btn" onClick={handleFinishWorkout}>
         Finish Workout
       </button>
+      {showSummary && (
+        <SessionSummaryModal
+          summary={summaryData}
+          onContinue={() => setShowSummary(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/styles/LifetimeSummary.css
+++ b/src/components/styles/LifetimeSummary.css
@@ -1,0 +1,48 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
+
+.lifetime-panel {
+  background: rgba(10, 10, 10, 0.8);
+  border: 2px solid #444;
+  border-radius: 8px;
+  padding: 20px;
+  color: #e9e9e9;
+  font-family: 'Orbitron', sans-serif;
+  width: 300px;
+  box-shadow: 0 0 15px #000;
+}
+
+.lifetime-header {
+  font-size: 20px;
+  text-align: center;
+  color: #38b000;
+  margin-bottom: 10px;
+  text-shadow: 0 0 5px #0f0;
+}
+
+.lifetime-subheader {
+  text-align: center;
+  font-size: 14px;
+  margin-bottom: 20px;
+}
+
+.lifetime-stats {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.lifetime-stats li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 14px;
+}
+
+.lifetime-stats li strong {
+  margin-left: auto;
+}
+
+.lifetime-stats svg {
+  flex-shrink: 0;
+}

--- a/src/components/styles/SessionSummary.css
+++ b/src/components/styles/SessionSummary.css
@@ -1,0 +1,90 @@
+@import url('https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap');
+
+.session-summary-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.4s ease-in forwards;
+}
+
+.session-summary-box {
+  background: #1b1b1b;
+  border: 2px solid #555;
+  border-radius: 10px;
+  padding: 30px;
+  width: 90%;
+  max-width: 420px;
+  color: #e0e0e0;
+  box-shadow: 0 0 20px #000;
+  font-family: 'Share Tech Mono', monospace;
+}
+
+.session-summary-header {
+  font-size: 26px;
+  color: #0f0;
+  text-align: center;
+  margin-bottom: 20px;
+  text-shadow: 0 0 6px #0f0;
+}
+
+.summary-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 20px;
+}
+
+.summary-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 18px;
+}
+
+.summary-list svg {
+  flex-shrink: 0;
+}
+
+.session-summary-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.log-btn,
+.continue-btn {
+  flex: 1;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 6px;
+  font-weight: bold;
+  font-family: 'Share Tech Mono', monospace;
+  cursor: pointer;
+}
+
+.log-btn {
+  background: #333;
+  color: #fff;
+}
+
+.log-btn:hover {
+  background: #444;
+}
+
+.continue-btn {
+  background: #0f0;
+  color: #000;
+}
+
+.continue-btn:hover {
+  background: #1aff1a;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- create SessionSummaryModal with neon terminal styling
- create LifetimeSummaryPanel styled like a stat screen
- add corresponding CSS files
- integrate SessionSummaryModal into WorkoutLogger

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850886d6838832f918ebb90325d1117