### PR TITLE
Add weight tracking and accountability popup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,40 +15,73 @@ import VictoryPhase from "./components/phases/VictoryPhase";
 import RoomNarrativeOverlay from "./components/RoomNarrativeOverlay";
 import FinalBossPhase from "./components/phases/FinalBossPhase";
 import XPBar from "./components/XPBar";
+import AccountabilityPopup from "./components/AccountabilityPopup";
 import { playSound, speakText, stopSound } from "./utils";
+
+const INITIAL_STATE = {
+  characterCreated: false,
+  studentName: "",
+  yearGroup: "",
+  gender: "",
+  weight: "",
+  workoutFocus: "",
+  avatar: "pirate",
+  introStage: 0,
+  currentRoom: null,
+  completedRooms: [],
+  visibleRooms: ["Mr. Watkins' Room"],
+  annotations: [],
+  inventory: [],
+  bossReady: false,
+  bossDefeated: false,
+  missedBlazePods: 0,
+  lootUnlocked: [],
+  xp: 0,
+  badges: [],
+  triggeredQuiz: false,
+  bossPhase: 0,
+  victory: false,
+  showOverlay: true,
+  enhancedReading: false,
+  textToSpeech: false,
+};
 
 function App() {
   const [signedIn, setSignedIn] = useState(false);
-  const [gameState, setGameState] = useState({
-    characterCreated: false,
-    studentName: "",
-    yearGroup: "",
-    gender: "",
-    weight: "",
-    workoutFocus: "",
-    avatar: "pirate",
-    introStage: 0,
-    currentRoom: null,
-    completedRooms: [],
-    visibleRooms: ["Mr. Watkins' Room"],
-    annotations: [],
-    inventory: [],
-    bossReady: false,
-    bossDefeated: false,
-    missedBlazePods: 0,
-    lootUnlocked: [],
-    xp: 0,
-    badges: [],
-    triggeredQuiz: false,
-    bossPhase: 0,
-    victory: false,
-    showOverlay: true,
-    enhancedReading: false,
-    textToSpeech: false,
-  });
+  const [gameState, setGameState] = useState({ ...INITIAL_STATE });
+  const [popupMessage, setPopupMessage] = useState(null);
 
   const ambientRef = useRef(null);
   const prevXpLevel = useRef(0);
+
+  useEffect(() => {
+    const now = new Date();
+    const lastOpen = localStorage.getItem('lastOpenDate');
+    if (!lastOpen || new Date(lastOpen).toDateString() !== now.toDateString()) {
+      setPopupMessage('Remember to log your workout today!');
+      localStorage.setItem('lastOpenDate', now.toISOString());
+    }
+
+    const week = JSON.parse(localStorage.getItem('weekData') || '{}');
+    if (!week.start) {
+      week.start = now.toISOString();
+      week.minutes = 0;
+    } else {
+      const start = new Date(week.start);
+      if (now - start >= 7 * 24 * 60 * 60 * 1000) {
+        if ((week.minutes || 0) >= 60) {
+          setPopupMessage('Great job! You hit your weekly workout target!');
+        } else {
+          setPopupMessage('You missed the weekly workout target. Starting over.');
+          setGameState({ ...INITIAL_STATE });
+          setSignedIn(false);
+        }
+        week.start = now.toISOString();
+        week.minutes = 0;
+      }
+    }
+    localStorage.setItem('weekData', JSON.stringify(week));
+  }, []);
 
   useEffect(() => {
     const level = Math.floor(gameState.xp / 100);
@@ -154,6 +187,9 @@ function App() {
         />
       )}
       {renderPhase()}
+      {popupMessage && (
+        <AccountabilityPopup message={popupMessage} onClose={() => setPopupMessage(null)} />
+      )}
     </div>
   );
 }

--- a/src/components/AccountabilityPopup.jsx
+++ b/src/components/AccountabilityPopup.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import "./styles/Overlay.css";
+
+function AccountabilityPopup({ message, onClose }) {
+  if (!message) return null;
+  return (
+    <div className="overlay-bg">
+      <div className="overlay-box">
+        <p>{message}</p>
+        <button onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+}
+
+export default AccountabilityPopup;

--- a/src/components/CharacterCreation.jsx
+++ b/src/components/CharacterCreation.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { setUserWeight } from "../utils";
 import { GiPirateCaptain, GiBlackKnightHelm, GiNinjaHead } from "react-icons/gi";
 import "./styles/CharacterCreation.css";
 
@@ -47,14 +48,16 @@ function CharacterCreation({ gameState, setGameState }) {
           <option value="M">M</option>
           <option value="F">F</option>
         </select>
-        <input
-          type="number"
-          placeholder="Weight (kg) - optional"
-          value={gameState.weight || ""}
-          onChange={(e) =>
-            setGameState({ ...gameState, weight: e.target.value })
-          }
-        />
+        <label>
+          Weight (kg)
+          <input
+            type="number"
+            value={gameState.weight || ""}
+            onChange={(e) =>
+              setGameState({ ...gameState, weight: e.target.value })
+            }
+          />
+        </label>
         <select
           value={gameState.workoutFocus || ""}
           onChange={(e) =>
@@ -105,13 +108,15 @@ function CharacterCreation({ gameState, setGameState }) {
           Text to Speech
         </label>
         <button
-          onClick={() =>
+          onClick={() => {
+            const wt = parseFloat(gameState.weight) || 50;
+            setUserWeight(wt);
             setGameState({
               ...gameState,
-              weight: parseFloat(gameState.weight) || 50,
+              weight: wt,
               characterCreated: true,
-            })
-          }
+            });
+          }}
         >
           Start Game
         </button>

--- a/src/components/LifetimeSummaryPanel.jsx
+++ b/src/components/LifetimeSummaryPanel.jsx
@@ -6,6 +6,7 @@ import {
   IoTrophy,
   IoShirt,
   IoCheckmarkCircle,
+  IoBody,
 } from "react-icons/io5";
 import "./styles/LifetimeSummary.css";
 
@@ -18,6 +19,7 @@ function LifetimeSummaryPanel({ username, summary }) {
     calories,
     bossesDefeated,
     cosmetics,
+    weight,
   } = summary;
 
   return (
@@ -29,6 +31,7 @@ function LifetimeSummaryPanel({ username, summary }) {
         <li><IoBarbell /> <span>Total Weight Lifted:</span> <strong>{weightLifted}</strong></li>
         <li><IoWalk /> <span>Distance Travelled:</span> <strong>{distance}</strong></li>
         <li><IoFlame /> <span>Total Calories Burned:</span> <strong>{calories}</strong></li>
+        <li><IoBody /> <span>Current Weight:</span> <strong>{weight || '-'}</strong></li>
         <li><IoTrophy /> <span>Bosses Defeated:</span> <strong>{bossesDefeated}</strong></li>
         <li><IoShirt /> <span>Cosmetics Unlocked:</span> <strong>{cosmetics}</strong></li>
       </ul>

--- a/src/components/SignIn.jsx
+++ b/src/components/SignIn.jsx
@@ -1,16 +1,30 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import "./styles/SignIn.css";
 import Leaderboard from "./Leaderboard";
+import LifetimeSummaryPanel from "./LifetimeSummaryPanel";
 
 function SignIn({ onSignIn }) {
+  const [username, setUsername] = useState("");
+  const [summary, setSummary] = useState(null);
+
+  useEffect(() => {
+    const data = localStorage.getItem("lifetimeSummary");
+    if (data) setSummary(JSON.parse(data));
+  }, []);
+
   return (
     <div className="signin-container">
       <div className="signin-box">
         <h2>Student Sign In</h2>
-        <input placeholder="Username" />
+        <input
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
         <input placeholder="Password" type="password" />
-        <button onClick={onSignIn}>Sign In</button>
+        <button onClick={() => onSignIn(username)}>Sign In</button>
       </div>
+      {summary && <LifetimeSummaryPanel username={username || "Player"} summary={summary} />}
       <Leaderboard />
     </div>
   );

--- a/src/components/WorkoutLogger.jsx
+++ b/src/components/WorkoutLogger.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { playSound } from "../utils";
+import { playSound, updateLifetimeSummary, logWorkoutMinutes } from "../utils";
 import SessionSummaryModal from "./SessionSummaryModal";
 import exerciseList from "../data/exerciseList";
 import cardioExercises from "../data/cardioExercises";
@@ -44,6 +44,12 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus }) {
     );
     const distance = workoutLog.reduce((sum, w) => sum + (parseFloat(w.distance) || 0), 0);
     const calories = Math.round(distance * 60 + totalWeight * 0.1);
+    const minutes = workoutLog.reduce((sum, w) => {
+      if (cardioMode) return sum + (parseFloat(w.duration) || 0);
+      const sets = parseFloat(w.sets) || 0;
+      const reps = parseFloat(w.reps) || 0;
+      return sum + (sets * reps * 3) / 60;
+    }, 0);
 
     setSummaryData({
       totalWeight: `${totalWeight.toFixed(1)} kg`,
@@ -52,6 +58,9 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus }) {
       exerciseCount: workoutLog.length,
     });
     setShowSummary(true);
+
+    updateLifetimeSummary({ weightLifted: totalWeight, distance, calories });
+    logWorkoutMinutes(minutes);
 
     setGameState((prev) => ({
       ...prev,

--- a/src/components/phases/FinalBossPhase.jsx
+++ b/src/components/phases/FinalBossPhase.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import ParallaxDust from "../ParallaxDust";
 import BlazePods from "../BlazePods";
-import { playSound } from "../../utils";
+import { playSound, updateLifetimeSummary, logWorkoutMinutes } from "../../utils";
 import "../styles/RoomScene.css";
 
 function FinalBossPhase({ setGameState }) {
@@ -48,6 +48,8 @@ function FinalBossPhase({ setGameState }) {
         workout: "Operation Slamstorm",
       },
     }));
+    updateLifetimeSummary({ calories: 0, bossesDefeated: 1 });
+    logWorkoutMinutes(timer / 60);
     playSound();
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -133,3 +133,30 @@ export function estimateCalories({
 
   return 0; // Unknown case
 }
+
+export function updateLifetimeSummary({ weightLifted = 0, distance = 0, calories = 0, bossesDefeated = 0 }) {
+  const data = JSON.parse(localStorage.getItem('lifetimeSummary') || '{}');
+  data.workouts = (data.workouts || 0) + 1;
+  data.weightLifted = +(data.weightLifted || 0) + weightLifted;
+  data.distance = +(data.distance || 0) + distance;
+  data.calories = +(data.calories || 0) + calories;
+  data.bossesDefeated = (data.bossesDefeated || 0) + bossesDefeated;
+  localStorage.setItem('lifetimeSummary', JSON.stringify(data));
+}
+
+export function setUserWeight(weight) {
+  const data = JSON.parse(localStorage.getItem('lifetimeSummary') || '{}');
+  data.weight = weight;
+  localStorage.setItem('lifetimeSummary', JSON.stringify(data));
+}
+
+export function logWorkoutMinutes(minutes) {
+  const now = new Date();
+  const week = JSON.parse(localStorage.getItem('weekData') || '{}');
+  if (!week.start) {
+    week.start = now.toISOString();
+    week.minutes = 0;
+  }
+  week.minutes += minutes;
+  localStorage.setItem('weekData', JSON.stringify(week));
+}


### PR DESCRIPTION
## Summary
- track player weight at character creation and store in summary
- display weight in lifetime summary panel
- add accountability popup for daily/weekly reminders
- keep weekly workout minutes and reset game on failure
- log workout minutes and update lifetime stats

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68508b4703c0832fb02a13e9e84cf81c