### PR TITLE
Upload button gated by workout completion

### DIFF
--- a/src/components/SessionSummaryModal.jsx
+++ b/src/components/SessionSummaryModal.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { IoBarbell, IoWalk, IoFlame, IoBook } from "react-icons/io5";
 import "./styles/SessionSummary.css";
 
-function SessionSummaryModal({ summary, onContinue, onViewLog }) {
+function SessionSummaryModal({ summary, onContinue, onViewLog, continueLabel = "Continue" }) {
   if (!summary) return null;
   const { totalWeight, distance, calories, exerciseCount } = summary;
   return (
@@ -19,7 +19,7 @@ function SessionSummaryModal({ summary, onContinue, onViewLog }) {
           {onViewLog && (
             <button className="log-btn" onClick={onViewLog}>View My Logbook</button>
           )}
-          <button className="continue-btn" onClick={onContinue}>Continue</button>
+          <button className="continue-btn" onClick={onContinue}>{continueLabel}</button>
         </div>
       </div>
     </div>

--- a/src/components/WorkoutLogger.jsx
+++ b/src/components/WorkoutLogger.jsx
@@ -6,7 +6,14 @@ import exerciseList from "../data/exerciseList";
 import cardioExercises from "../data/cardioExercises";
 import "./styles/WorkoutLogger.css";
 
-function WorkoutLogger({ roomNumber, setGameState, workoutFocus, userId }) {
+function WorkoutLogger({
+  roomNumber,
+  setGameState,
+  workoutFocus,
+  userId,
+  onComplete,
+  completeLabel = "Continue",
+}) {
   const cardioMode = workoutFocus === "cardio";
   const allowedCategories = ["Core", "Legs", "Chest", "Back", "Arms", "Functional"];
   const filteredExerciseList = exerciseList.filter((ex) =>
@@ -86,6 +93,13 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus, userId }) {
       ],
     }));
     playSound();
+  };
+
+  const handleSummaryContinue = () => {
+    setShowSummary(false);
+    if (onComplete) {
+      onComplete();
+    }
   };
 
   return (
@@ -175,7 +189,8 @@ function WorkoutLogger({ roomNumber, setGameState, workoutFocus, userId }) {
       {showSummary && (
         <SessionSummaryModal
           summary={summaryData}
-          onContinue={() => setShowSummary(false)}
+          onContinue={handleSummaryContinue}
+          continueLabel={completeLabel}
         />
       )}
     </div>

--- a/src/components/phases/Room1.jsx
+++ b/src/components/phases/Room1.jsx
@@ -88,10 +88,9 @@ function Room1({ setGameState, gameState }) {
               setGameState={setGameState}
               workoutFocus={gameState.workoutFocus}
               userId={gameState.studentName}
+              onComplete={handleUploadWorkout}
+              completeLabel="Upload Your Workout"
             />
-            <button className="primary-btn" onClick={handleUploadWorkout}>
-              Upload Your Workout
-            </button>
           </>
         )}
 

--- a/src/components/phases/Room2.jsx
+++ b/src/components/phases/Room2.jsx
@@ -138,10 +138,9 @@ function Room2({ setGameState, gameState }) {
             setGameState={setGameState}
             workoutFocus={gameState.workoutFocus}
             userId={gameState.studentName}
+            onComplete={handleUploadWorkout}
+            completeLabel="Upload Your Workout"
           />
-          <button className="primary-btn" onClick={handleUploadWorkout}>
-            Upload Your Workout
-          </button>
         </>
       )}
 

--- a/src/components/phases/Room3Boss.jsx
+++ b/src/components/phases/Room3Boss.jsx
@@ -140,13 +140,9 @@ function Room3Boss({ setGameState, gameState }) {
             setGameState={setGameState}
             workoutFocus={gameState.workoutFocus}
             userId={gameState.studentName}
+            onComplete={() => setWorkoutLogged(true)}
+            completeLabel="Upload Your Workout"
           />
-          <button
-            className="primary-btn"
-            onClick={() => setWorkoutLogged(true)}
-          >
-            Upload Your Workout
-          </button>
         </>
       )}
 


### PR DESCRIPTION
## Summary
- allow custom button text in `SessionSummaryModal`
- add callback props to `WorkoutLogger` to notify parent when a workout is finished
- show the summary button as **Upload Your Workout** in each room
- remove separate upload buttons from rooms

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850997d2220832f8267e915c89707e0