### PR TITLE
Centralize narration text

### DIFF
--- a/src/components/MapIntroduction.jsx
+++ b/src/components/MapIntroduction.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import ParallaxDust from "./ParallaxDust";
 import "./styles/RoomScene.css";
 import { playSound } from "../utils";
+import narrationLines from "../data/narrationLines";
 
 function MapIntroduction({ setGameState }) {
   const handleViewMap = () => {
@@ -28,27 +29,9 @@ function MapIntroduction({ setGameState }) {
       <ParallaxDust />
       <div className="room-content rpg-text">
         <h2>🎒 A New Beginning</h2>
-        <p>
-          You step into the dim hallway, breathing heavy after escaping the locker room.
-          Just as you start to gather your bearings, something crunches under your foot.
-        </p>
-      <p>
-        A torn, dusty <strong>school bag</strong> lies abandoned near the lockers. Its straps are frayed,
-        but it feels sturdy enough to carry what you need.
-      </p>
-      <p>
-        Inside, you find a battered <strong>pamphlet-style school map</strong>, marked with strange scribbles:
-        <em>“DO NOT ENTER - Roche?”</em> scrawled in red. Some rooms are circled. Others crossed out.
-      </p>
-      <p>
-        Alongside it, an old sticky note: <em>“If you're reading this... stick to the Languages Wing.”</em>
-      </p>
-      <p>
-        You sling the bag over your shoulder. From now on, you can collect supplies and keep track of your path.
-      </p>
-        <p>
-          Mr. Watkins' room looks slightly ajar. It might be worth investigating first.
-        </p>
+        {narrationLines.mapIntroduction.map((line, idx) => (
+          <p key={idx}>{line}</p>
+        ))}
         <button onClick={handleViewMap}>View Map and Begin Exploring</button>
       </div>
     </div>

--- a/src/components/RoomNarrativeOverlay.jsx
+++ b/src/components/RoomNarrativeOverlay.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { GiPirateCaptain, GiBlackKnightHelm, GiNinjaHead } from "react-icons/gi";
 import "./styles/Overlay.css";
 import { playSound } from "../utils";
+import narrationLines from "../data/narrationLines";
 
 const avatarIcons = {
   pirate: <GiPirateCaptain />,
@@ -14,31 +15,12 @@ function RoomNarrativeOverlay({ roomName, avatar, onContinue }) {
     const audio = playSound('openingDoor');
     return () => audio && audio.pause();
   }, []);
-  const introText = {
-    "Mr. Watkins' Room": [
-      "You push open the door to Mr. Watkins' classroom. It's eerily quiet.",
-      "Dust floats in the light. Papers are scattered across the desks.",
-      "You step inside, unsure if you're alone…",
-    ],
-    "Mrs. John's Room": [
-      "You head further into the Languages corridor. Mrs. John's classroom is barely lit.",
-      "Desks are overturned and chairs are jammed against the back of the door. You squeeze through.",
-      "There's a faint buzzing—maybe the lights? Or something else. You need to scavenge supplies quickly and quietly.",
-    ],
-    "Mrs. Roche's Room": [
-      "The air feels heavier as you reach Mrs. Roche's classroom.",
-      "Something doesn't feel right. You hear movement inside.",
-      "You grip your bag tighter. This could be trouble.",
-    ],
-  };
-
   const introImages = {
     "Mr. Watkins' Room": "/Mr_WatkinsDoor.png",
     "Mrs. John's Room": "/Mrs_JohnsDoor.png",
     "Mrs. Roche's Room": "/Mrs_RochesDoor.png",
   };
-
-  const lines = introText[roomName] || ["You enter the room…"];
+  const lines = narrationLines.overlayIntro[roomName] || ["You enter the room…"];
 
   return (
     <div className="overlay-bg">

--- a/src/components/phases/EscapePhase.jsx
+++ b/src/components/phases/EscapePhase.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
 import { playSound } from "../../utils";
+import narrationLines from "../../data/narrationLines";
 
 function EscapePhase({ setGameState, slamBallGoal = 10, squatJumpGoal = 15 }) {
   const [slamBalls, setSlamBalls] = useState(0);
@@ -29,21 +30,20 @@ function EscapePhase({ setGameState, slamBallGoal = 10, squatJumpGoal = 15 }) {
       <ParallaxDust />
       <div className="room-content rpg-text">
         <h2>🔧 Escape Options</h2>
-        <p>
-          You finally grab the object—it’s a flathead screwdriver. Not much… but it could help.
-        </p>
-        <p>
-          You check the door: locked. But maybe you can loosen it. Or… there's a bench nearby. Could
-          you climb and escape through the ceiling tiles?
-        </p>
-        <p>🧠 Choose your escape route:</p>
+        {narrationLines.escaping.slice(0,3).map((line, idx) => (
+          <p key={idx}>{line}</p>
+        ))}
         <div>
-          <p>💪 Use the screwdriver to jimmy the lock—{slamBallGoal} slam balls</p>
+          <p>
+            {narrationLines.escaping[3].replace('{slamBallGoal}', slamBallGoal)}
+          </p>
           <button onClick={() => setSlamBalls(slamBalls + 1)}>Do Slam Ball</button>
           <p>Progress: {slamBalls}/{slamBallGoal}</p>
         </div>
         <div>
-          <p>⚡ Leap onto the bench and push up into the tiles—{squatJumpGoal} squat jumps</p>
+          <p>
+            {narrationLines.escaping[4].replace('{squatJumpGoal}', squatJumpGoal)}
+          </p>
           <button onClick={() => setJumpSquats(jumpSquats + 1)}>Do Squat Jump</button>
           <p>Progress: {jumpSquats}/{squatJumpGoal}</p>
         </div>

--- a/src/components/phases/IntroPhase.jsx
+++ b/src/components/phases/IntroPhase.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
 import { playVoice, playSound } from "../../utils";
+import narrationLines from "../../data/narrationLines";
 
 function IntroPhase({ setGameState }) {
   useEffect(() => {
@@ -13,21 +14,9 @@ function IntroPhase({ setGameState }) {
       <ParallaxDust />
       <div className="room-content rpg-text">
         <h2>🧊 Locked In</h2>
-        <p>
-          You were stuffed into a locker by bullies. You shouted for help, but no one came.
-          Then… the evacuation alarm rang. Panic erupted outside. You screamed… and passed
-          out from the lack of air.
-        </p>
-        <p>⏱️ 24 hours later…</p>
-        <p>
-          You awake—cold, cramped, and alone. The building is silent. Lights flicker. You
-          scream again… nothing.
-        </p>
-        <p>
-          💥 Using the last of your strength, you kick the locker door until it swings open.
-          You collapse out onto the changing room floor, freezing cold.
-        </p>
-        <p>You must get warm fast or risk freezing in the dark...</p>
+        {narrationLines.introPhase.map((line, idx) => (
+          <p key={idx}>{line}</p>
+        ))}
         <button onClick={() => {
           playSound('footsteps');
           setGameState((prev) => ({ ...prev, introStage: 1 }));

--- a/src/components/phases/Room1.jsx
+++ b/src/components/phases/Room1.jsx
@@ -3,6 +3,7 @@ import WorkoutLogger from "../WorkoutLogger";
 import ParallaxDust from "../ParallaxDust";
 import { playSound } from "../../utils";
 import "../styles/RoomScene.css";
+import narrationLines from "../../data/narrationLines";
 
 function Room1({ setGameState, gameState }) {
   const [workoutUploaded, setWorkoutUploaded] = useState(false);
@@ -82,7 +83,7 @@ function Room1({ setGameState, gameState }) {
 
         {!workoutUploaded && (
           <>
-            <p>You cautiously enter the abandoned classroom. The stale air and dust hint that no one has been here for a while. It's the perfect moment to focus and log your workout.</p>
+            <p>{narrationLines.room1.intro}</p>
             <WorkoutLogger
               roomNumber={1}
               setGameState={setGameState}
@@ -96,18 +97,18 @@ function Room1({ setGameState, gameState }) {
 
       {workoutUploaded && !scavengeCompleted && (
         <>
-          <p>With your body re-energized, you notice something odd under a pile of worksheets. You kneel to investigate...</p>
+          <p>{narrationLines.room1.scavengeIntro}</p>
           <button onClick={handleScavenge}>See Your Scavenging Results</button>
         </>
       )}
 
       {scavengeCompleted && foundItem && !restReady && (
-        <p>You pocket the <strong>{foundItem}</strong>. It shows another room labeled "Mrs. John's Room" – previously unknown. A breakthrough!</p>
+        <p>{narrationLines.room1.foundItem.replace('{item}', foundItem)}</p>
       )}
 
         {restReady && (
           <>
-            <p>Feeling the fatigue set in, you choose to rest in a safe corner. Tomorrow, you'll explore the newly revealed room.</p>
+            <p>{narrationLines.room1.rest}</p>
             <button onClick={handleRest}>Rest Up for the Night</button>
           </>
         )}

--- a/src/components/phases/Room2.jsx
+++ b/src/components/phases/Room2.jsx
@@ -4,6 +4,7 @@ import WorkoutLogger from "../WorkoutLogger";
 import SafeQuizEvent from "../events/SafeQuizEvent";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
+import narrationLines from "../../data/narrationLines";
 
 const languageQuestions = [
   {
@@ -132,7 +133,7 @@ function Room2({ setGameState, gameState }) {
 
       {!workoutUploaded && (
         <>
-          <p>You arrive in Mrs. John's classroom. It's eerily quiet, but there's space to complete your next workout.</p>
+          <p>{narrationLines.room2.intro}</p>
           <WorkoutLogger
             roomNumber={2}
             setGameState={setGameState}
@@ -146,7 +147,7 @@ function Room2({ setGameState, gameState }) {
 
       {safeDiscovered && !quizActive && !quizCompleted && (
         <>
-          <p>While catching your breath, you notice a flicker under the teacher's desk. It's a dusty digital safe with a keypad!</p>
+          <p>{narrationLines.room2.safeDiscovery}</p>
           <button onClick={() => setQuizActive(true)}>Attempt to Unlock the Safe</button>
         </>
       )}
@@ -164,21 +165,17 @@ function Room2({ setGameState, gameState }) {
         <>
           {lootFound ? (
             <>
-              <p>You found <strong>{lootFound}</strong> inside the safe. Nicely done!</p>
-              <p>Inside the safe, you also find a scribbled note:</p>
-              <blockquote>
-                "If anyone finds this, Roche has barricaded herself in the far room. I heard growling… Stay away unless you're ready."
-              </blockquote>
-              <p>You pocket the bar and steel yourself. It might be time to face what’s in there.</p>
+              <p>{narrationLines.room2.lootFound.replace('{loot}', lootFound)}</p>
+              <p>{narrationLines.room2.noteFound}</p>
+              <blockquote>{narrationLines.room2.noteQuote}</blockquote>
+              <p>{narrationLines.room2.readyMessage}</p>
             </>
           ) : (
             <>
-              <p>You couldn't crack the safe. You'll need to complete 15 ground-to-overheads to brute force it open.</p>
-              <p>After forcing it open, you find a crumpled note:</p>
-              <blockquote>
-                "Roche… far room… something’s wrong… don’t go alone."
-              </blockquote>
-              <p>You swallow hard. Time to prepare.</p>
+              <p>{narrationLines.room2.lootFailure}</p>
+              <p>{narrationLines.room2.failureNote}</p>
+              <blockquote>{narrationLines.room2.noteQuote}</blockquote>
+              <p>{narrationLines.room2.swallowHard}</p>
             </>
           )}
           <button onClick={handleReturnToMap}>Return to the Map</button>

--- a/src/components/phases/WarmUpPhase.jsx
+++ b/src/components/phases/WarmUpPhase.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
 import { playSound } from "../../utils";
+import narrationLines from "../../data/narrationLines";
 
 function WarmUpPhase({ setGameState }) {
   useEffect(() => {
@@ -16,11 +17,9 @@ function WarmUpPhase({ setGameState }) {
       <ParallaxDust />
       <div className="room-content rpg-text">
         <h2>🔥 Warm-Up</h2>
-        <p>
-          Your muscles ache. You shuffle across the room, rubbing your arms. You spot a dusty
-          rowing machine still plugged in.
-        </p>
-        <p>🏃 To raise your heart rate, complete a 500m row.</p>
+        {narrationLines.warmupIntro.map((line, idx) => (
+          <p key={idx}>{line}</p>
+        ))}
         <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}>
           Row Complete
         </button>

--- a/src/data/narrationLines.js
+++ b/src/data/narrationLines.js
@@ -1,0 +1,64 @@
+const narrationLines = {
+  introPhase: [
+    "You were stuffed into a locker by bullies. You shouted for help, but no one came. Then… the evacuation alarm rang. Panic erupted outside. You screamed…and passed out from the lack of air.",
+    "\u23F1\uFE0F 24 hours later…",
+    "You awake—cold, cramped, and alone. The building is silent. Lights flicker. You scream again… nothing.",
+    "💥 Using the last of your strength, you kick the locker door until it swings open. You collapse out onto the changing room floor, freezing cold.",
+    "You must get warm fast or risk freezing in the dark...",
+  ],
+  warmupIntro: [
+    "Your muscles ache. You shuffle across the room, rubbing your arms. You spot a dusty rowing machine still plugged in.",
+    "\uD83C\uDFC3 To raise your heart rate, complete a 500m row.",
+  ],
+  escaping: [
+    "You finally grab the object—it’s a flathead screwdriver. Not much… but it could help.",
+    "You check the door: locked. But maybe you can loosen it. Or… there's a bench nearby. Could you climb and escape through the ceiling tiles?",
+    "\uD83E\uDDE0 Choose your escape route:",
+    "\uD83D\uDCAA Use the screwdriver to jimmy the lock—{slamBallGoal} slam balls",
+    "\u26A1\uFE0F Leap onto the bench and push up into the tiles—{squatJumpGoal} squat jumps",
+  ],
+  mapIntroduction: [
+    "You step into the dim hallway, breathing heavy after escaping the locker room. Just as you start to gather your bearings, something crunches under your foot.",
+    "A torn, dusty school bag lies abandoned near the lockers. Its straps are frayed, but it feels sturdy enough to carry what you need.",
+    "Inside, you find a battered pamphlet-style school map, marked with strange scribbles: \"DO NOT ENTER - Roche?\" Some rooms are circled. Others crossed out.",
+    "Alongside it, an old sticky note: \"If you're reading this... stick to the Languages Wing.\"",
+    "You sling the bag over your shoulder. From now on, you can collect supplies and keep track of your path.",
+    "Mr. Watkins' room looks slightly ajar. It might be worth investigating first.",
+  ],
+  room1: {
+    intro: "You cautiously enter the abandoned classroom. The stale air and dust hint that no one has been here for a while. It's the perfect moment to focus and log your workout.",
+    scavengeIntro: "With your body re-energized, you notice something odd under a pile of worksheets. You kneel to investigate...",
+    foundItem: 'You pocket the {item}. It shows another room labeled "Mrs. John\'s Room" – previously unknown. A breakthrough!',
+    rest: "Feeling the fatigue set in, you choose to rest in a safe corner. Tomorrow, you'll explore the newly revealed room.",
+  },
+  room2: {
+    intro: "You arrive in Mrs. John's classroom. It's eerily quiet, but there's space to complete your next workout.",
+    safeDiscovery: "While catching your breath, you notice a flicker under the teacher's desk. It's a dusty digital safe with a keypad!",
+    lootFound: 'You found {loot} inside the safe. Nicely done!',
+    noteFound: 'Inside the safe, you also find a scribbled note:',
+    noteQuote: '"If anyone finds this, Roche has barricaded herself in the far room. I heard growling… Stay away unless you\'re ready."',
+    lootFailure: "You couldn't crack the safe. You'll need to complete 15 ground-to-overheads to brute force it open.",
+    failureNote: 'After forcing it open, you find a crumpled note: "Roche… far room… something’s wrong… don’t go alone."',
+    readyMessage: 'You pocket the bar and steel yourself. It might be time to face what’s in there.',
+    swallowHard: 'You swallow hard. Time to prepare.',
+  },
+  overlayIntro: {
+    "Mr. Watkins' Room": [
+      "You push open the door to Mr. Watkins' classroom. It's eerily quiet.",
+      "Dust floats in the light. Papers are scattered across the desks.",
+      "You step inside, unsure if you're alone…",
+    ],
+    "Mrs. John's Room": [
+      "You head further into the Languages corridor. Mrs. John's classroom is barely lit.",
+      "Desks are overturned and chairs are jammed against the back of the door. You squeeze through.",
+      "There's a faint buzzing—maybe the lights? Or something else. You need to scavenge supplies quickly and quietly.",
+    ],
+    "Mrs. Roche's Room": [
+      "The air feels heavier as you reach Mrs. Roche's classroom.",
+      "Something doesn't feel right. You hear movement inside.",
+      "You grip your bag tighter. This could be trouble.",
+    ],
+  },
+};
+
+export default narrationLines;


### PR DESCRIPTION
## Summary
- add `/src/data/narrationLines.js` with grouped story text
- load narration lines in Intro, Warm-Up, Escape, MapIntro, Room1 & Room2
- use narration lines in the room overlay component
- build project to ensure compilation

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68512bd4a0a0832f94440abef03659ce