### PR TITLE
Add warmup prompt with display

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -118,7 +118,12 @@ function App() {
       case 0:
         return <IntroPhase setGameState={setGameState} />;
       case 1:
-        return <WarmUpPhase setGameState={setGameState} />;
+        return (
+          <WarmUpPhase
+            setGameState={setGameState}
+            gameState={gameState}
+          />
+        );
       case 2:
         return <MobilityPhase setGameState={setGameState} />;
       case 3:

--- a/src/components/phases/WarmUpPhase.jsx
+++ b/src/components/phases/WarmUpPhase.jsx
@@ -1,31 +1,42 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
 import { playSound } from "../../utils";
 import narrationLines from "../../data/narrationLines";
+import WarmupDisplay from "../WarmupDisplay";
 
-function WarmUpPhase({ setGameState }) {
+function WarmUpPhase({ setGameState, gameState }) {
+  const [showWarmup, setShowWarmup] = useState(false);
   useEffect(() => {
     const timer = setTimeout(() => {
       playSound('rowing');
     }, 5000);
     return () => clearTimeout(timer);
   }, []);
-  return (
-    <div className="room-container">
-      <img src="/RowingMachine.png" alt="Rowing Machine" className="scene-image" />
-      <ParallaxDust />
-      <div className="room-content rpg-text">
-        <h2>🔥 Warm-Up</h2>
-        {narrationLines.general.warmupIntro.map((line, idx) => (
-          <p key={idx}>{line}</p>
-        ))}
-        <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}>
-          Row Complete
-        </button>
+    return (
+      <div className="room-container">
+        <img src="/RowingMachine.png" alt="Rowing Machine" className="scene-image" />
+        <ParallaxDust />
+        <div className="room-content rpg-text">
+          <h2>🔥 Warm-Up</h2>
+          {showWarmup ? (
+            <WarmupDisplay
+              focus={gameState?.workoutFocus}
+              onComplete={() =>
+                setGameState((prev) => ({ ...prev, introStage: 2 }))
+              }
+            />
+          ) : (
+            <>
+              {narrationLines.general.warmupIntro.map((line, idx) => (
+                <p key={idx}>{line}</p>
+              ))}
+              <button onClick={() => setShowWarmup(true)}>Start Warm-Up</button>
+            </>
+          )}
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
 
-export default WarmUpPhase;
+  export default WarmUpPhase;


### PR DESCRIPTION
## Summary
- show a warm-up routine using `WarmupDisplay`
- pass `gameState` to `WarmUpPhase`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685155e6a608832f8425d163a4384e6c