### PR TITLE
Add warmup selection and safe failure challenge

### DIFF
--- a/src/components/RoomTemplate.jsx
+++ b/src/components/RoomTemplate.jsx
@@ -39,6 +39,7 @@ function RoomTemplate({
   const [stage, setStage] = useState('narration');
   const [loot, setLoot] = useState(null);
   const [warmupDone, setWarmupDone] = useState(!requiresWarmup);
+  const [warmupFocus, setWarmupFocus] = useState(gameState.workoutFocus || 'legs');
 
   const lines = Array.isArray(narrationKey)
     ? narrationKey
@@ -46,7 +47,7 @@ function RoomTemplate({
   const safeIntroLines = safeIntroKey ? getLinesByKey(safeIntroKey) : [];
 
   const handleNarrationDone = () => {
-    if (requiresWarmup && !warmupDone) setStage('warmup');
+    if (requiresWarmup && !warmupDone) setStage('warmupPrompt');
     else if (hasWorkout) setStage('workout');
     else if (hasScavenge) setStage('scavenge');
     else setStage('complete');
@@ -57,6 +58,16 @@ function RoomTemplate({
     if (hasWorkout) setStage('workout');
     else if (hasScavenge) setStage('scavenge');
     else setStage('complete');
+  };
+
+  const handleWarmupDecision = (wantWarmup) => {
+    if (wantWarmup) setStage('warmupSelect');
+    else handleWarmupComplete();
+  };
+
+  const handleFocusSelect = (focus) => {
+    setWarmupFocus(focus);
+    setStage('warmup');
   };
 
   const handleWorkoutComplete = () => {
@@ -83,11 +94,16 @@ function RoomTemplate({
   };
 
   const handleBossComplete = () => {
-    setGameState((prev) => ({
-      ...prev,
-      xp: (prev.xp || 0) + 20,
-      completedRooms: [...(prev.completedRooms || []), mapMarker],
-    }));
+    setGameState((prev) => {
+      const updates = {
+        xp: (prev.xp || 0) + 20,
+        completedRooms: [...(prev.completedRooms || []), mapMarker],
+      };
+      if (unlocksRoom && !prev.visibleRooms.includes(unlocksRoom)) {
+        updates.visibleRooms = [...prev.visibleRooms, unlocksRoom];
+      }
+      return { ...prev, ...updates };
+    });
     if (lootPool) setStage('loot');
     else setStage('complete');
   };
@@ -159,10 +175,31 @@ function RoomTemplate({
     );
   }
 
+  if (stage === 'warmupPrompt') {
+    return (
+      <div className="rpg-text room-content">
+        <p>Log your workout. Would you like a pre-built warm up before starting?</p>
+        <button onClick={() => handleWarmupDecision(true)}>Yes</button>
+        <button onClick={() => handleWarmupDecision(false)}>No</button>
+      </div>
+    );
+  }
+
+  if (stage === 'warmupSelect') {
+    return (
+      <div className="rpg-text room-content">
+        <p>What are you training? Legs, Upper Body or Both?</p>
+        <button onClick={() => handleFocusSelect('legs')}>Legs</button>
+        <button onClick={() => handleFocusSelect('upperBody')}>Upper Body</button>
+        <button onClick={() => handleFocusSelect('full')}>Both</button>
+      </div>
+    );
+  }
+
   if (stage === 'warmup') {
     return (
       <WarmupDisplay
-        focus={workoutFocus || gameState.workoutFocus}
+        focus={warmupFocus}
         onComplete={handleWarmupComplete}
       />
     );

--- a/src/components/WarmupDisplay.jsx
+++ b/src/components/WarmupDisplay.jsx
@@ -2,8 +2,8 @@ import React from "react";
 import warmups from "../data/warmups";
 import "./styles/WarmupDisplay.css";
 
-function WarmupDisplay({ focus = "legs", onComplete }) {
-  const warmup = warmups[focus] || warmups.legs;
+function WarmupDisplay({ focus = "full", onComplete }) {
+  const warmup = warmups[focus] || warmups.full;
 
   return (
     <div className="warmup-display">

--- a/src/components/events/SafeQuizEvent.jsx
+++ b/src/components/events/SafeQuizEvent.jsx
@@ -4,6 +4,18 @@ import { playSound } from "../../utils";
 
 const baseUrl = import.meta.env.BASE_URL || "/";
 
+const FAILURE_EXERCISES = [
+  "10 burpees",
+  "15 jump squats",
+  "10 slam balls",
+  "15 wall balls",
+  "50 skips",
+  "10 push ups",
+  "30 second plank",
+  "12 box jumps",
+  "10 ground-to-overheads",
+];
+
 const SafeQuizEvent = ({
   questionPool,
   onSuccess,
@@ -44,9 +56,10 @@ const SafeQuizEvent = ({
       setFeedback("Incorrect ❌");
 
       if (lives - 1 === 0) {
+        const exercise = FAILURE_EXERCISES[Math.floor(Math.random() * FAILURE_EXERCISES.length)];
         setQuizCompleted(true);
-        setFeedback("Access Denied. You must now complete a physical challenge.");
-        onFailure();
+        setFeedback(`Access Denied. You must now complete ${exercise} to break it open.`);
+        onFailure(exercise);
       }
     }
   };

--- a/src/components/phases/Room3Boss.jsx
+++ b/src/components/phases/Room3Boss.jsx
@@ -2,15 +2,20 @@ import React from "react";
 import RoomTemplate from "../RoomTemplate";
 import quizPool from "../../data/quizPool";
 import bossData from "../../data/bossData";
+import roomData from "../../data/roomData";
 
 function Room3Boss(props) {
+  const config = roomData.mrsRoche;
   return (
     <RoomTemplate
       {...props}
       narrationKey="languages.rocheBoss.leadIn"
       quiz={quizPool.languages.rocheBoss}
       boss={bossData.languages.roche}
-      mapMarker="Mrs. Roche's Room"
+      mapMarker={config.id}
+      requiresWarmup={config.requiresWarmup}
+      hasWorkout={config.hasWorkout}
+      unlocksRoom={config.unlocksRoom}
     />
   );
 }

--- a/src/data/roomData.js
+++ b/src/data/roomData.js
@@ -13,6 +13,13 @@ export const roomData = {
     hasScavenge: false,
     unlocksRoom: "Mrs. Roche's Room",
   },
+  mrsRoche: {
+    id: "Mrs. Roche's Room",
+    requiresWarmup: true,
+    hasWorkout: true,
+    hasScavenge: false,
+    unlocksRoom: "Fitness Suite",
+  },
 };
 
 export default roomData;

--- a/src/data/warmups.js
+++ b/src/data/warmups.js
@@ -17,6 +17,15 @@ const warmups = {
       { phase: "Potentiate", action: "10 explosive incline push-ups" },
     ],
   },
+  full: {
+    name: "Full Body – Dynamic RAMP",
+    steps: [
+      { phase: "Raise", action: "Row 250m or use Assault Bike for 1 min" },
+      { phase: "Activate", action: "10 arm circles and 10 lunges" },
+      { phase: "Mobilize", action: "5 deep squats and 5 shoulder rolls" },
+      { phase: "Potentiate", action: "10 burpees" },
+    ],
+  },
 };
 
 export default warmups;


### PR DESCRIPTION
## Summary
- let players choose leg/upper body/full warm-ups before workouts
- add full body warmup option
- random physical task on safe quiz failure
- unlock Mrs. Roche's room and the Fitness Suite
- queue room config for Mrs. Roche

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68519fc4ba74832f8ef0af802f79ab7d