### PR TITLE
Improve warmups and badge reward

### DIFF
--- a/src/components/BadgeUnlockedModal.jsx
+++ b/src/components/BadgeUnlockedModal.jsx
@@ -7,7 +7,7 @@ function BadgeUnlockedModal({ badgeId, onClose }) {
   if (!badgeId) return null;
   const badge = badgeDefinitions[badgeId] || {};
   return (
-    <div className="overlay-bg">
+    <div className="overlay-bg badge-unlock-bg">
       <div className="overlay-box badge-earned">
         {badge.image ? (
           <img src={badge.image} alt={badge.label} className="badge-img" />

--- a/src/components/RoomTemplate.jsx
+++ b/src/components/RoomTemplate.jsx
@@ -38,6 +38,7 @@ function RoomTemplate({
 }) {
   const [stage, setStage] = useState('narration');
   const [loot, setLoot] = useState(null);
+  const [failureExercise, setFailureExercise] = useState(null);
   const [warmupDone, setWarmupDone] = useState(!requiresWarmup);
   const [warmupFocus, setWarmupFocus] = useState(gameState.workoutFocus || 'legs');
 
@@ -142,7 +143,29 @@ function RoomTemplate({
     }
   };
 
-  const handleSafeFailure = () => {};
+  const handleSafeFailure = (exercise) => {
+    setFailureExercise(exercise);
+  };
+
+  const handleSafeComplete = () => {
+    if (failureExercise) {
+      setStage('safePenalty');
+    } else if (lootPool) setStage('loot');
+    else setStage('complete');
+  };
+
+  const handlePenaltyDone = () => {
+    const reward = {
+      id: 'safe_energy_bar',
+      name: 'Energy Bar',
+      rarity: 'uncommon',
+      description: 'Restores stamina when used.',
+    };
+    handleSafeSuccess(reward);
+    setFailureExercise(null);
+    if (lootPool) setStage('loot');
+    else setStage('complete');
+  };
 
   const handleLoot = () => {
     const found = getRandomLoot(lootPool);
@@ -240,10 +263,7 @@ function RoomTemplate({
         questionPool={safeQuiz}
         onSuccess={handleSafeSuccess}
         onFailure={handleSafeFailure}
-        onComplete={() => {
-          if (lootPool) setStage('loot');
-          else setStage('complete');
-        }}
+        onComplete={handleSafeComplete}
         roomName={mapMarker}
       />
     );
@@ -251,6 +271,15 @@ function RoomTemplate({
 
   if (stage === 'quiz') {
     return <QuizPhase questions={quiz} onComplete={handleQuizComplete} />;
+  }
+
+  if (stage === 'safePenalty') {
+    return (
+      <div className="rpg-text room-content">
+        <p>To force the safe open, complete {failureExercise}.</p>
+        <button onClick={handlePenaltyDone}>I've done it</button>
+      </div>
+    );
   }
 
   if (stage === 'boss') {

--- a/src/components/phases/WarmUpPhase.jsx
+++ b/src/components/phases/WarmUpPhase.jsx
@@ -1,32 +1,71 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
+import WarmupDisplay from "../WarmupDisplay";
 import { playSound } from "../../utils";
 import narrationLines from "../../data/narrationLines";
 
 
 function WarmUpPhase({ setGameState }) {
+  const [stage, setStage] = useState('intro');
+  const [focus, setFocus] = useState('legs');
+
   useEffect(() => {
     const timer = setTimeout(() => {
       playSound('rowing');
     }, 5000);
     return () => clearTimeout(timer);
   }, []);
-  return (
-    <div className="room-container">
-      <img src="/RowingMachine.png" alt="Rowing Machine" className="scene-image" />
-      <ParallaxDust />
-      <div className="room-content rpg-text">
-        <h2>🔥 Warm-Up</h2>
-        {narrationLines.general.warmupIntro.map((line, idx) => (
-          <p key={idx}>{line}</p>
-        ))}
+
+  if (stage === 'intro') {
+    return (
+      <div className="room-container">
+        <img src="/RowingMachine.png" alt="Rowing Machine" className="scene-image" />
+        <ParallaxDust />
+        <div className="room-content rpg-text">
+          <h2>🔥 Warm-Up</h2>
+          {narrationLines.general.warmupIntro.map((line, idx) => (
+            <p key={idx}>{line}</p>
+          ))}
+          <button onClick={() => setStage('prompt')}>Continue</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (stage === 'prompt') {
+    return (
+      <div className="rpg-text room-content">
+        <p>Would you like a guided RAMP warm up?</p>
+        <button onClick={() => setStage('select')}>Yes</button>
         <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}>
-          Continue
+          Skip
         </button>
       </div>
-    </div>
-  );
+    );
+  }
+
+  if (stage === 'select') {
+    return (
+      <div className="rpg-text room-content">
+        <p>Choose your focus.</p>
+        <button onClick={() => { setFocus('legs'); setStage('warmup'); }}>Legs</button>
+        <button onClick={() => { setFocus('upperBody'); setStage('warmup'); }}>Upper Body</button>
+        <button onClick={() => { setFocus('full'); setStage('warmup'); }}>Both</button>
+      </div>
+    );
+  }
+
+  if (stage === 'warmup') {
+    return (
+      <WarmupDisplay
+        focus={focus}
+        onComplete={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}
+      />
+    );
+  }
+
+  return null;
 }
 
 export default WarmUpPhase;

--- a/src/components/styles/BadgePopup.css
+++ b/src/components/styles/BadgePopup.css
@@ -1,7 +1,12 @@
 .badge-earned {
   text-align: center;
+  padding: 20px;
 }
 .badge-earned .badge-img {
-  width: 80px;
+  width: 150px;
   margin-bottom: 10px;
+  filter: drop-shadow(0 0 6px #fff);
+}
+.badge-unlock-bg {
+  background: rgba(0, 0, 0, 0.95);
 }

--- a/src/components/styles/Overlay.css
+++ b/src/components/styles/Overlay.css
@@ -10,6 +10,9 @@
   align-items: center;
   color: #fff;
 }
+.badge-unlock-bg {
+  background: rgba(0, 0, 0, 0.9);
+}
 
 .overlay-box {
   background: #222;


### PR DESCRIPTION
## Summary
- restyle badge unlock screen with larger image and darker overlay
- add warm up selection to introduction phase
- handle safe quiz penalties and let player do an exercise to open the safe

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851d1f0bc4c832f97b98600c37a4ab3