### PR TITLE
Add Firestore lifetime summary

### DIFF
--- a/src/components/LifetimeSummaryPanel.jsx
+++ b/src/components/LifetimeSummaryPanel.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
   IoBarbell,
   IoWalk,
@@ -10,13 +10,39 @@ import {
 } from "react-icons/io5";
 import "./styles/LifetimeSummary.css";
 
-function LifetimeSummaryPanel({ username, summary }) {
-  if (!summary) return null;
+import { fetchWorkoutSummary } from "../helpers/fetchWorkoutSummary";
+
+function LifetimeSummaryPanel({ userId = "test-user", username }) {
+  const [summary, setSummary] = useState({
+    totalWorkouts: 0,
+    totalWeight: 0,
+    totalDistance: 0,
+    totalCalories: 0,
+    bossesDefeated: 0,
+    cosmetics: 0,
+    weight: null,
+  });
+
+  useEffect(() => {
+    const loadSummary = async () => {
+      const liveSummary = await fetchWorkoutSummary(userId);
+      if (liveSummary) {
+        setSummary((prev) => ({ ...prev, ...liveSummary }));
+        localStorage.setItem("lifetimeSummary", JSON.stringify(liveSummary));
+      } else {
+        const cached = localStorage.getItem("lifetimeSummary");
+        if (cached) setSummary(JSON.parse(cached));
+      }
+    };
+
+    loadSummary();
+  }, [userId]);
+
   const {
-    workouts,
-    weightLifted,
-    distance,
-    calories,
+    totalWorkouts,
+    totalWeight,
+    totalDistance,
+    totalCalories,
     bossesDefeated,
     cosmetics,
     weight,
@@ -24,16 +50,34 @@ function LifetimeSummaryPanel({ username, summary }) {
 
   return (
     <div className="lifetime-panel">
-      <h2 className="lifetime-header">Welcome back, {username}!</h2>
+      <h2 className="lifetime-header">Welcome back{username ? `, ${username}!` : "!"}</h2>
       <p className="lifetime-subheader">Your progress so far:</p>
       <ul className="lifetime-stats">
-        <li><IoCheckmarkCircle /> <span>Workouts Completed:</span> <strong>{workouts}</strong></li>
-        <li><IoBarbell /> <span>Total Weight Lifted:</span> <strong>{weightLifted}</strong></li>
-        <li><IoWalk /> <span>Distance Travelled:</span> <strong>{distance}</strong></li>
-        <li><IoFlame /> <span>Total Calories Burned:</span> <strong>{calories}</strong></li>
-        <li><IoBody /> <span>Current Weight:</span> <strong>{weight || '-'}</strong></li>
-        <li><IoTrophy /> <span>Bosses Defeated:</span> <strong>{bossesDefeated}</strong></li>
-        <li><IoShirt /> <span>Cosmetics Unlocked:</span> <strong>{cosmetics}</strong></li>
+        <li>
+          <IoCheckmarkCircle /> <span>Workouts Completed:</span>{" "}
+          <strong>{totalWorkouts}</strong>
+        </li>
+        <li>
+          <IoBarbell /> <span>Total Weight Lifted:</span>{" "}
+          <strong>{totalWeight.toFixed ? totalWeight.toFixed(1) : totalWeight}</strong>
+        </li>
+        <li>
+          <IoWalk /> <span>Distance Travelled:</span>{" "}
+          <strong>{totalDistance.toFixed ? totalDistance.toFixed(1) : totalDistance}</strong>
+        </li>
+        <li>
+          <IoFlame /> <span>Total Calories Burned:</span>{" "}
+          <strong>{totalCalories}</strong>
+        </li>
+        <li>
+          <IoBody /> <span>Current Weight:</span> <strong>{weight || "-"}</strong>
+        </li>
+        <li>
+          <IoTrophy /> <span>Bosses Defeated:</span> <strong>{bossesDefeated}</strong>
+        </li>
+        <li>
+          <IoShirt /> <span>Cosmetics Unlocked:</span> <strong>{cosmetics}</strong>
+        </li>
       </ul>
     </div>
   );

--- a/src/components/SignIn.jsx
+++ b/src/components/SignIn.jsx
@@ -1,16 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import "./styles/SignIn.css";
 import Leaderboard from "./Leaderboard";
 import LifetimeSummaryPanel from "./LifetimeSummaryPanel";
 
 function SignIn({ onSignIn }) {
   const [username, setUsername] = useState("");
-  const [summary, setSummary] = useState(null);
 
-  useEffect(() => {
-    const data = localStorage.getItem("lifetimeSummary");
-    if (data) setSummary(JSON.parse(data));
-  }, []);
 
   return (
     <div className="signin-container">
@@ -24,7 +19,7 @@ function SignIn({ onSignIn }) {
         <input placeholder="Password" type="password" />
         <button onClick={() => onSignIn(username)}>Sign In</button>
       </div>
-      {summary && <LifetimeSummaryPanel username={username || "Player"} summary={summary} />}
+      <LifetimeSummaryPanel userId={username || "test-user"} username={username || "Player"} />
       <Leaderboard />
     </div>
   );

--- a/src/helpers/fetchWorkoutSummary.js
+++ b/src/helpers/fetchWorkoutSummary.js
@@ -1,0 +1,30 @@
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../firebase";
+
+export const fetchWorkoutSummary = async (userId = "test-user") => {
+  try {
+    const querySnapshot = await getDocs(collection(db, "students", userId, "workouts"));
+    const workouts = querySnapshot.docs.map((doc) => doc.data());
+
+    const summary = workouts.reduce(
+      (acc, workout) => {
+        acc.totalWeight += workout.totalWeightLifted || 0;
+        acc.totalDistance += workout.distanceTravelled || 0;
+        acc.totalCalories += workout.caloriesBurned || 0;
+        acc.totalWorkouts += 1;
+        return acc;
+      },
+      {
+        totalWeight: 0,
+        totalDistance: 0,
+        totalCalories: 0,
+        totalWorkouts: 0,
+      }
+    );
+
+    return summary;
+  } catch (error) {
+    console.error("\u274c Failed to fetch workout summary:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add helper to read workout data from Firestore
- show live lifetime stats in `LifetimeSummaryPanel`
- update sign-in screen to use new summary panel

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851d7502d70832fb7e260a74b0253ba