### PR TITLE
Add Firebase login form and use user uid

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import SignIn from "./components/SignIn";
+import LoginForm from "./components/LoginForm";
 import CharacterCreation from "./components/CharacterCreation";
 import IntroPhase from "./components/phases/IntroPhase";
 import WarmUpPhase from "./components/phases/WarmUpPhase";
@@ -48,7 +48,7 @@ const INITIAL_STATE = {
 };
 
 function App() {
-  const [signedIn, setSignedIn] = useState(false);
+  const [user, setUser] = useState(null);
   const [gameState, setGameState] = useState({ ...INITIAL_STATE });
   const [popupMessage, setPopupMessage] = useState(null);
   const [recentBadge, setRecentBadge] = useState(null);
@@ -77,7 +77,7 @@ function App() {
         } else {
           setPopupMessage('You missed the weekly workout target. Starting over.');
           setGameState({ ...INITIAL_STATE });
-          setSignedIn(false);
+          setUser(null);
         }
         week.start = now.toISOString();
         week.minutes = 0;
@@ -105,7 +105,7 @@ function App() {
   }, [gameState.badges]);
 
   useEffect(() => {
-    if (!signedIn || gameState.introStage === 0) {
+    if (!user || gameState.introStage === 0) {
       if (!ambientRef.current) {
         ambientRef.current = playSound('ambient', { loop: true, volume: 0.2 });
       }
@@ -113,17 +113,17 @@ function App() {
       stopSound(ambientRef.current);
       ambientRef.current = null;
     }
-  }, [signedIn, gameState.introStage]);
+  }, [user, gameState.introStage]);
 
   useEffect(() => {
     if (gameState.textToSpeech) {
       const el = document.querySelector('.rpg-text');
       if (el) speakText(el.innerText);
     }
-  }, [gameState.textToSpeech, gameState.introStage, gameState.currentRoom, gameState.showOverlay, signedIn]);
+  }, [gameState.textToSpeech, gameState.introStage, gameState.currentRoom, gameState.showOverlay, user]);
 
   const renderPhase = () => {
-    if (!signedIn) return <SignIn onSignIn={() => setSignedIn(true)} />;
+    if (!user) return <LoginForm onLogin={(u) => setUser(u)} />;
     if (!gameState.characterCreated)
       return <CharacterCreation gameState={gameState} setGameState={setGameState} />;
 
@@ -165,6 +165,7 @@ function App() {
             <Room1
               setGameState={setGameState}
               gameState={gameState}
+              userId={user?.uid}
             />
           );
         }
@@ -173,14 +174,19 @@ function App() {
             <Room2
               setGameState={setGameState}
               gameState={gameState}
+              userId={user?.uid}
             />
           );
         }
         if (gameState.currentRoom === "Mrs. Roche's Room") {
-          return <Room3Boss setGameState={setGameState} gameState={gameState} />;
+          return (
+            <Room3Boss setGameState={setGameState} gameState={gameState} userId={user?.uid} />
+          );
         }
         if (gameState.currentRoom === "Fitness Suite") {
-          return <FinalBossPhase setGameState={setGameState} gameState={gameState} />;
+          return (
+            <FinalBossPhase setGameState={setGameState} gameState={gameState} userId={user?.uid} />
+          );
         }
         break;
       case 7:
@@ -197,7 +203,7 @@ function App() {
 
   return (
     <div className={gameState.enhancedReading ? "enhanced-reading" : ""}>
-      {signedIn && gameState.characterCreated && (
+      {user && gameState.characterCreated && (
         <XPBar
           avatar={gameState.avatar}
           xp={gameState.xp}

--- a/src/components/LifetimeSummaryPanel.jsx
+++ b/src/components/LifetimeSummaryPanel.jsx
@@ -12,7 +12,7 @@ import "./styles/LifetimeSummary.css";
 
 import { fetchWorkoutSummary } from "../helpers/fetchWorkoutSummary";
 
-function LifetimeSummaryPanel({ userId = "test-user", username }) {
+function LifetimeSummaryPanel({ userId, username }) {
   const [summary, setSummary] = useState({
     totalWorkouts: 0,
     totalWeight: 0,

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from "firebase/auth";
+import { auth } from "../firebase";
+
+export default function LoginForm({ onLogin }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleLogin = async (e) => {
+    e.preventDefault();
+    try {
+      const result = await signInWithEmailAndPassword(auth, email, password);
+      onLogin(result.user);
+    } catch (err) {
+      try {
+        const result = await createUserWithEmailAndPassword(auth, email, password);
+        onLogin(result.user);
+      } catch (error) {
+        alert("Login failed: " + error.message);
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={handleLogin}>
+      <h2>Student Login</h2>
+      <input
+        type="email"
+        placeholder="Your school email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        placeholder="Choose a password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <button type="submit">Log In</button>
+    </form>
+  );
+}

--- a/src/components/RoomTemplate.jsx
+++ b/src/components/RoomTemplate.jsx
@@ -31,6 +31,7 @@ function RoomTemplate({
   mapMarker,
   gameState,
   setGameState,
+  userId,
   requiresWarmup = false,
   hasWorkout = false,
   hasScavenge = false,
@@ -238,7 +239,7 @@ function RoomTemplate({
             roomNumber={mapMarker}
             setGameState={setGameState}
             workoutFocus={workoutFocus || gameState.workoutFocus}
-            userId={gameState.studentName}
+            userId={userId}
             onComplete={handleWorkoutComplete}
             completeLabel="Upload Your Workout"
           />

--- a/src/components/SignIn.jsx
+++ b/src/components/SignIn.jsx
@@ -19,7 +19,7 @@ function SignIn({ onSignIn }) {
         <input placeholder="Password" type="password" />
         <button onClick={() => onSignIn(username)}>Sign In</button>
       </div>
-      <LifetimeSummaryPanel userId={username || "test-user"} username={username || "Player"} />
+      <LifetimeSummaryPanel userId={username} username={username || "Player"} />
       <Leaderboard />
     </div>
   );

--- a/src/components/WorkoutLogger.jsx
+++ b/src/components/WorkoutLogger.jsx
@@ -107,7 +107,6 @@ function WorkoutLogger({
   };
 
   const saveWorkoutToFirestore = async (workoutData) => {
-    const userId = "test-user"; // Replace this with real user ID once authentication is set up
     try {
       await addDoc(collection(db, "students", userId, "workouts"), {
         ...workoutData,

--- a/src/helpers/fetchWorkoutSummary.js
+++ b/src/helpers/fetchWorkoutSummary.js
@@ -1,8 +1,9 @@
 import { collection, getDocs } from "firebase/firestore";
 import { db } from "../firebase";
 
-export const fetchWorkoutSummary = async (userId = "test-user") => {
+export const fetchWorkoutSummary = async (userId) => {
   try {
+    if (!userId) return null;
     const querySnapshot = await getDocs(collection(db, "students", userId, "workouts"));
     const workouts = querySnapshot.docs.map((doc) => doc.data());
 


### PR DESCRIPTION
## Summary
- add LoginForm component for Firebase email/password auth
- switch App to use LoginForm and keep user state
- route user uid to rooms and workout logger
- update Firestore helper and logger to use provided userId
- minor cleanup of SignIn defaults

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851d94b75ac832fb98c8c3886cd26c9