### PR TITLE
Add env logging and ignore secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.env

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -3,6 +3,8 @@ import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 import { getStorage } from "firebase/storage";
 
+console.log("\ud83d\udd11 Firebase API Key:", import.meta.env.VITE_FIREBASE_API_KEY);
+
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,


### PR DESCRIPTION
## Summary
- print Firebase API key when firebase module loads
- ignore `.env` so credentials aren't committed

## Testing
- `npm install`
- `npm run build`
- `npm run dev` *(fails: requires accessible browser)*

------
https://chatgpt.com/codex/tasks/task_e_68528233883c832fb8ec441e74873375