### PR TITLE
Improve warmup flow and boss transition

### DIFF
--- a/src/components/RoomTemplate.jsx
+++ b/src/components/RoomTemplate.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import narrationLines from '../data/narrationLines';
 import NarrationManager from './NarrationManager';
 import WorkoutLogger from './WorkoutLogger';
@@ -20,13 +20,14 @@ function getLinesByKey(key) {
 }
 
 
-function RoomTemplate({
+  function RoomTemplate({
   narrationKey,
   workoutFocus,
   quiz,
   safeQuiz,
   safeIntroKey,
-  boss,
+    boss,
+    quizIntroKey,
   lootPool,
   mapMarker,
   gameState,
@@ -47,6 +48,14 @@ function RoomTemplate({
     ? narrationKey
     : getLinesByKey(narrationKey);
   const safeIntroLines = safeIntroKey ? getLinesByKey(safeIntroKey) : [];
+  const quizIntroLines = quizIntroKey ? getLinesByKey(quizIntroKey) : [];
+
+  useEffect(() => {
+    if (stage === 'quizIntro') {
+      const timer = setTimeout(() => setStage('quiz'), 10000);
+      return () => clearTimeout(timer);
+    }
+  }, [stage]);
 
   const handleNarrationDone = () => {
     if (requiresWarmup && !warmupDone) setStage('warmupPrompt');
@@ -79,6 +88,7 @@ function RoomTemplate({
     }));
     if (safeQuiz) setStage('safeIntro');
     else if (hasScavenge) setStage('scavenge');
+    else if (quizIntroKey) setStage('quizIntro');
     else if (quiz) setStage('quiz');
     else if (boss) setStage('boss');
     else if (lootPool) setStage('loot');
@@ -103,6 +113,10 @@ function RoomTemplate({
       };
       if (unlocksRoom && !prev.visibleRooms.includes(unlocksRoom)) {
         updates.visibleRooms = [...prev.visibleRooms, unlocksRoom];
+      }
+      if (mapMarker === "Mrs. Roche's Room") {
+        updates.currentRoom = 'Fitness Suite';
+        updates.showOverlay = true;
       }
       return { ...prev, ...updates };
     });
@@ -270,8 +284,24 @@ function RoomTemplate({
     );
   }
 
+  if (stage === 'quizIntro') {
+    return (
+      <NarrationManager
+        lines={quizIntroLines}
+        onComplete={() => setStage('quiz')}
+        backgroundImage="/quiz_door.png"
+      />
+    );
+  }
+
   if (stage === 'quiz') {
-    return <QuizPhase questions={quiz} onComplete={handleQuizComplete} />;
+    return (
+      <QuizPhase
+        questions={quiz}
+        onComplete={handleQuizComplete}
+        showImpossibleFinal={mapMarker === "Mrs. Roche's Room"}
+      />
+    );
   }
 
   if (stage === 'safePenalty') {

--- a/src/components/phases/Room3Boss.jsx
+++ b/src/components/phases/Room3Boss.jsx
@@ -10,6 +10,7 @@ function Room3Boss(props) {
     <RoomTemplate
       {...props}
       narrationKey="languages.rocheBoss.leadIn"
+      quizIntroKey="languages.rocheBoss.quizIntro"
       quiz={quizPool.languages.rocheBoss}
       boss={bossData.languages.roche}
       mapMarker={config.id}

--- a/src/components/phases/WarmUpPhase.jsx
+++ b/src/components/phases/WarmUpPhase.jsx
@@ -27,20 +27,8 @@ function WarmUpPhase({ setGameState }) {
           {narrationLines.general.warmupIntro.map((line, idx) => (
             <p key={idx}>{line}</p>
           ))}
-          <button onClick={() => setStage('prompt')}>Continue</button>
+          <button onClick={() => setStage('select')}>Continue</button>
         </div>
-      </div>
-    );
-  }
-
-  if (stage === 'prompt') {
-    return (
-      <div className="rpg-text room-content">
-        <p>Would you like a guided RAMP warm up?</p>
-        <button onClick={() => setStage('select')}>Yes</button>
-        <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}>
-          Skip
-        </button>
       </div>
     );
   }

--- a/src/data/narrationLines.js
+++ b/src/data/narrationLines.js
@@ -67,6 +67,11 @@ const narrationLines = {
     },
     rocheBoss: {
       leadIn: ["Everything seems normal. You take a breath and prepare to log your workout."],
+      quizIntro: [
+        "A shadowy figure rises from behind the desk and shambles toward you.",
+        "You sprint for the exit, but the door slams shut—six heavy locks click into place.",
+        "Answer every question to release the locks!",
+      ],
       battleStart: "⚠️ An alarm blares. The door slams shut. Six glowing locks appear. You're trapped.",
     },
   },

--- a/src/data/warmups.js
+++ b/src/data/warmups.js
@@ -1,6 +1,6 @@
 const warmups = {
   legs: {
-    name: "Legs – Dynamic RAMP",
+    name: "Legs – Dynamic Warm Up",
     steps: [
       { phase: "Raise", action: "Row 250m or use Assault Bike for 1 min" },
       { phase: "Activate", action: "15 alternating forward lunges" },
@@ -9,7 +9,7 @@ const warmups = {
     ],
   },
   upperBody: {
-    name: "Upper Body – Dynamic RAMP",
+    name: "Upper Body – Dynamic Warm Up",
     steps: [
       { phase: "Raise", action: "Ski Erg for 1 min or row 200m" },
       { phase: "Activate", action: "10 arm circles (forward and backward)" },
@@ -18,7 +18,7 @@ const warmups = {
     ],
   },
   full: {
-    name: "Full Body – Dynamic RAMP",
+    name: "Full Body – Dynamic Warm Up",
     steps: [
       { phase: "Raise", action: "Row 250m or use Assault Bike for 1 min" },
       { phase: "Activate", action: "10 arm circles and 10 lunges" },


### PR DESCRIPTION
## Summary
- streamline warmup by removing the prompt stage and renaming RAMP warm ups
- add intro sequence for Mrs. Roche quiz with timed transition
- include impossible final question in Roche quiz
- move player automatically to Fitness Suite after defeating Roche

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685297fee500832fa163eb71986c44dd