### PR TITLE
Remove warmup prompt from locker room

### DIFF
--- a/src/components/phases/MobilityPhase.jsx
+++ b/src/components/phases/MobilityPhase.jsx
@@ -4,9 +4,9 @@ import "../styles/RoomScene.css";
 import { playSound } from "../../utils";
 
 function MobilityPhase({ setGameState }) {
-  const handleStretchComplete = () => {
-    // Transition to escape phase after completing stretches
-    setGameState((prev) => ({ ...prev, introStage: 3 })); // Move to escape phase
+  const handleGrabObject = () => {
+    // Move directly to the escape phase after retrieving the item
+    setGameState((prev) => ({ ...prev, introStage: 3 }));
     playSound();
   };
 
@@ -15,16 +15,13 @@ function MobilityPhase({ setGameState }) {
       <img src="/Shiny_Object.png" alt="Shiny Object" className="scene-image" />
       <ParallaxDust />
       <div className="room-content rpg-text">
-        <h2>🧍‍♂️ Mobility Stretch</h2>
+        <h2>🔎 Hidden Object</h2>
         <p>
-          With your blood flowing, you explore the changing room. A locker lies tipped on its side—
-          underneath it, something shiny glints in the flickering light.
+          As you explore the changing room, you spot a locker tipped on its side—
+          underneath, something shiny glints in the flickering light.
         </p>
-        <p>
-          You crawl forward… but your body is still stiff from the locker. You can’t quite reach.
-        </p>
-        <p>💪 Perform 10 lunges and 10 arm circles to loosen up.</p>
-        <button onClick={handleStretchComplete}>Stretch Complete</button>
+        <p>You reach carefully under the locker and feel a cold metal tool.</p>
+        <button onClick={handleGrabObject}>Take the object</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove the stretch mini-task from `MobilityPhase`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852a335dae0832fadf25ae039587b3b