### PR TITLE
Add bodyweight support in workout logger

### DIFF
--- a/src/components/WorkoutLogger.jsx
+++ b/src/components/WorkoutLogger.jsx
@@ -1,5 +1,12 @@
 import React, { useState } from "react";
-import { playSound, updateLifetimeSummary, logWorkoutMinutes } from "../utils";
+import {
+  playSound,
+  updateLifetimeSummary,
+  logWorkoutMinutes,
+  getUserWeight,
+  parseWeightInput,
+  formatWeightDisplay,
+} from "../utils";
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "../firebase";
 import SessionSummaryModal from "./SessionSummaryModal";
@@ -28,29 +35,38 @@ function WorkoutLogger({
   const [workoutLog, setWorkoutLog] = useState([]);
   const [showSummary, setShowSummary] = useState(false);
   const [summaryData, setSummaryData] = useState(null);
+  const userWeight = getUserWeight();
 
   const handleAddExercise = () => {
     if (cardioMode) {
       if (exerciseInput.name && exerciseInput.duration && exerciseInput.distance) {
         setWorkoutLog([
           ...workoutLog,
-          { ...exerciseInput, type: "Cardio", category: "Cardio" },
+          { ...exerciseInput, type: "Cardio", category: "Cardio", numericWeight: 0 },
         ]);
         setExerciseInput({ name: "", duration: "", distance: "" });
       }
     } else {
       if (exerciseInput.name && exerciseInput.sets && exerciseInput.reps && exerciseInput.weight) {
-        setWorkoutLog([...workoutLog, exerciseInput]);
+        const numericWeight = parseWeightInput(exerciseInput.weight, userWeight);
+        const displayWeight = formatWeightDisplay(exerciseInput.weight);
+        setWorkoutLog([
+          ...workoutLog,
+          { ...exerciseInput, weight: displayWeight, numericWeight },
+        ]);
         setExerciseInput({ name: "", sets: "", reps: "", weight: "" });
       }
     }
   };
 
   const handleFinishWorkout = () => {
-    const totalWeight = workoutLog.reduce(
-      (sum, w) => sum + ((parseFloat(w.sets) || 0) * (parseFloat(w.reps) || 0) * (parseFloat(w.weight) || 0)),
-      0
-    );
+    const totalWeight = workoutLog.reduce((sum, w) => {
+      const weight =
+        w.numericWeight !== undefined
+          ? w.numericWeight
+          : parseWeightInput(w.weight, userWeight);
+      return sum + (parseFloat(w.sets) || 0) * (parseFloat(w.reps) || 0) * weight;
+    }, 0);
     const distance = workoutLog.reduce((sum, w) => sum + (parseFloat(w.distance) || 0), 0);
     const calories = Math.round(distance * 60 + totalWeight * 0.1);
     const minutes = workoutLog.reduce((sum, w) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -150,6 +150,30 @@ export function setUserWeight(weight) {
   localStorage.setItem('lifetimeSummary', JSON.stringify(data));
 }
 
+export function getUserWeight() {
+  const data = JSON.parse(localStorage.getItem('lifetimeSummary') || '{}');
+  return +(data.weight || 50);
+}
+
+export function parseWeightInput(input, userWeight) {
+  if (!input && input !== 0) return 0;
+  const str = String(input).trim();
+  if (/^bw$/i.test(str) || str === '0') return userWeight;
+  const bwMatch = str.match(/^bw\s*\+\s*([0-9]+(?:\.[0-9]+)?)$/i);
+  if (bwMatch) return userWeight + parseFloat(bwMatch[1]);
+  const n = parseFloat(str);
+  return isNaN(n) ? 0 : n;
+}
+
+export function formatWeightDisplay(input) {
+  if (input === null || input === undefined) return '';
+  const str = String(input).trim();
+  if (/^bw$/i.test(str) || str === '0') return 'Bodyweight';
+  const bwMatch = str.match(/^bw\s*\+\s*([0-9]+(?:\.[0-9]+)?)$/i);
+  if (bwMatch) return `Bodyweight + ${bwMatch[1]}kg`;
+  return /kg$/i.test(str) ? str : `${str}kg`;
+}
+
 export function logWorkoutMinutes(minutes) {
   const now = new Date();
   const week = JSON.parse(localStorage.getItem('weekData') || '{}');


### PR DESCRIPTION
## Summary
- allow bodyweight notation when logging workouts
- compute lifted weight using user's weight when `BW` or `BW+X` is entered
- show `Bodyweight` or `Bodyweight + Xkg` in workout logs
- expose helper functions for handling user weight and weight parsing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852a3b28828832f8740c76c5ae52641