### PR TITLE
feat: add multi-phase Roche boss fight

### DIFF
--- a/src/components/phases/BossFightPhase.jsx
+++ b/src/components/phases/BossFightPhase.jsx
@@ -1,33 +1,71 @@
-import React from "react";
+import React, { useState } from "react";
 
-function BossFightPhase({ gameState, setGameState }) {
-  const lootBasedOnPerformance = () => {
-    if (gameState.quizScore >= 5) {
-      return ["🧾 Rare Logbook", "🎽 Golden Cosmetic"];
-    } else if (gameState.quizScore >= 3) {
-      return ["🧾 Standard Logbook", "🎽 Basic Cosmetic"];
-    } else {
-      return ["🧾 Torn Logbook"];
-    }
-  };
+function BossFightPhase({ config = {}, gameState, setGameState, onComplete }) {
+  const [step, setStep] = useState(0);
 
-  const loot = lootBasedOnPerformance();
+  const next = () => setStep((s) => s + 1);
 
-  const handleDefeat = () => {
-    setGameState((prev) => ({ ...prev, bossDefeated: true, lootUnlocked: loot }));
-  };
+  if (step === 0) {
+    return (
+      <div className="rpg-text room-content">
+        <p>The monster barges the door, the bolt beginning to loosen.</p>
+        <button onClick={next}>Prepare</button>
+      </div>
+    );
+  }
 
-  return (
-    <div style={{ padding: 20 }}>
-      <h2>👹 Boss Fight: Mutated Mrs Roche</h2>
-      <p>🏋️ 21-15-9: Box jumps, slam balls, Calories</p>
-      <p>
-        ⚡ Missed BlazePods: {gameState.missedBlazePods} → Burn{" "}
-        {gameState.missedBlazePods * 5} calories post-fight!
-      </p>
-      <button onClick={handleDefeat}>Complete Battle</button>
-    </div>
-  );
+  if (step === 1) {
+    const p = config.phases?.[0] || { reps: 12, exercise: "Burpees" };
+    return (
+      <div className="rpg-text room-content">
+        <p>The mutated boss swings a ruler at you!</p>
+        <p>Perform {p.reps} {p.exercise} to dodge.</p>
+        <button onClick={next}>I've done it</button>
+      </div>
+    );
+  }
+
+  if (step === 2) {
+    return (
+      <div className="rpg-text room-content">
+        <p>
+          You have successfully avoided the shadowy figure's attacks and one of
+          the missed hits has loosened the lock. One more attack should do it.
+        </p>
+        <button onClick={next}>Continue</button>
+      </div>
+    );
+  }
+
+  if (step === 3) {
+    const p = config.phases?.[1] || { reps: 20, exercise: "Side Bunny Hops" };
+    return (
+      <div className="rpg-text room-content">
+        <p>The boss lashes out even quicker in irritation.</p>
+        <p>Complete {p.reps} {p.exercise} to stay unharmed.</p>
+        <button onClick={next}>I've done it</button>
+      </div>
+    );
+  }
+
+  if (step === 4) {
+    return (
+      <div className="rpg-text room-content">
+        <p>The boss misses and smashes the door open, the lock falling off.</p>
+        <p>You sprint down the hallway toward the fitness suite.</p>
+        <button
+          onClick={() => {
+            setGameState && setGameState((prev) => ({ ...prev, bossDefeated: true }));
+            onComplete && onComplete();
+          }}
+        >
+          Enter Fitness Suite
+        </button>
+      </div>
+    );
+  }
+
+  return null;
 }
 
 export default BossFightPhase;

--- a/src/components/phases/QuizPhase.jsx
+++ b/src/components/phases/QuizPhase.jsx
@@ -183,12 +183,7 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
       <div className="quiz-container">
         <h2>🎉 Quiz Complete</h2>
         <p>You answered {correctAnswers} out of {totalQuestions} correctly.</p>
-        {finalWrong && (
-          <p>
-            A mutated figure charges at you! You dive aside as it smashes the
-            door open.
-          </p>
-        )}
+        <p>The monster suddenly barges the door. You notice the bolt loosen slightly.</p>
         <button onClick={() => onComplete(correctAnswers, totalQuestions)}>Continue</button>
       </div>
     );

--- a/src/data/bossData.js
+++ b/src/data/bossData.js
@@ -4,16 +4,16 @@ export const bossData = {
       name: 'Mutated Mrs Roche',
       phases: [
         {
-          title: 'Ground Stomp',
-          description: 'Jump onto the desk to avoid the shockwave.',
-          reps: 15,
-          exercise: 'Burpee Box Jumps',
+          title: 'Ruler Slash',
+          description: 'Dive aside from the sweeping blow.',
+          reps: 12,
+          exercise: 'Burpees',
         },
         {
-          title: 'Whipping Spiral',
-          description: 'Leap laterally to dodge the tail.',
+          title: 'Frantic Swipes',
+          description: 'Hop quickly to avoid the flurry.',
           reps: 20,
-          exercise: 'Lateral Bunny Hops',
+          exercise: 'Side Bunny Hops',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- add new multi-step boss fight after the quiz
- show bolt loosening message at quiz completion
- update boss data with new phase details

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a778c2a8832fb1d0eddbbc2651f3