### PR TITLE
Remove dynamic warm-up from intro row

### DIFF
--- a/src/components/phases/WarmUpPhase.jsx
+++ b/src/components/phases/WarmUpPhase.jsx
@@ -1,15 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
-import WarmupDisplay from "../WarmupDisplay";
 import { playSound } from "../../utils";
 import narrationLines from "../../data/narrationLines";
 
-
 function WarmUpPhase({ setGameState }) {
-  const [stage, setStage] = useState('intro');
-  const [focus, setFocus] = useState('legs');
-
   useEffect(() => {
     const timer = setTimeout(() => {
       playSound('rowing');
@@ -17,43 +12,21 @@ function WarmUpPhase({ setGameState }) {
     return () => clearTimeout(timer);
   }, []);
 
-  if (stage === 'intro') {
-    return (
-      <div className="room-container">
-        <img src="/RowingMachine.png" alt="Rowing Machine" className="scene-image" />
-        <ParallaxDust />
-        <div className="room-content rpg-text">
-          <h2>🔥 Warm-Up</h2>
-          {narrationLines.general.warmupIntro.map((line, idx) => (
-            <p key={idx}>{line}</p>
-          ))}
-          <button onClick={() => setStage('select')}>Continue</button>
-        </div>
+  return (
+    <div className="room-container">
+      <img src="/RowingMachine.png" alt="Rowing Machine" className="scene-image" />
+      <ParallaxDust />
+      <div className="room-content rpg-text">
+        <h2>🔥 Warm-Up</h2>
+        {narrationLines.general.warmupIntro.map((line, idx) => (
+          <p key={idx}>{line}</p>
+        ))}
+        <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}>
+          I've rowed 500m
+        </button>
       </div>
-    );
-  }
-
-  if (stage === 'select') {
-    return (
-      <div className="rpg-text room-content">
-        <p>Choose your focus.</p>
-        <button onClick={() => { setFocus('legs'); setStage('warmup'); }}>Legs</button>
-        <button onClick={() => { setFocus('upperBody'); setStage('warmup'); }}>Upper Body</button>
-        <button onClick={() => { setFocus('full'); setStage('warmup'); }}>Both</button>
-      </div>
-    );
-  }
-
-  if (stage === 'warmup') {
-    return (
-      <WarmupDisplay
-        focus={focus}
-        onComplete={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}
-      />
-    );
-  }
-
-  return null;
+    </div>
+  );
 }
 
 export default WarmUpPhase;


### PR DESCRIPTION
## Summary
- streamline WarmUpPhase so the player only rows 500m in the locker room

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852ab56cb34832fb47db2b9920a68e5