### PR TITLE
Revert multi-phase boss fight

### DIFF
--- a/src/components/phases/BossFightPhase.jsx
+++ b/src/components/phases/BossFightPhase.jsx
@@ -1,71 +1,33 @@
-import React, { useState } from "react";
+import React from "react";
 
-function BossFightPhase({ config = {}, gameState, setGameState, onComplete }) {
-  const [step, setStep] = useState(0);
+function BossFightPhase({ gameState, setGameState }) {
+  const lootBasedOnPerformance = () => {
+    if (gameState.quizScore >= 5) {
+      return ["🧾 Rare Logbook", "🎽 Golden Cosmetic"];
+    } else if (gameState.quizScore >= 3) {
+      return ["🧾 Standard Logbook", "🎽 Basic Cosmetic"];
+    } else {
+      return ["🧾 Torn Logbook"];
+    }
+  };
 
-  const next = () => setStep((s) => s + 1);
+  const loot = lootBasedOnPerformance();
 
-  if (step === 0) {
-    return (
-      <div className="rpg-text room-content">
-        <p>The monster barges the door, the bolt beginning to loosen.</p>
-        <button onClick={next}>Prepare</button>
-      </div>
-    );
-  }
+  const handleDefeat = () => {
+    setGameState((prev) => ({ ...prev, bossDefeated: true, lootUnlocked: loot }));
+  };
 
-  if (step === 1) {
-    const p = config.phases?.[0] || { reps: 12, exercise: "Burpees" };
-    return (
-      <div className="rpg-text room-content">
-        <p>The mutated boss swings a ruler at you!</p>
-        <p>Perform {p.reps} {p.exercise} to dodge.</p>
-        <button onClick={next}>I've done it</button>
-      </div>
-    );
-  }
-
-  if (step === 2) {
-    return (
-      <div className="rpg-text room-content">
-        <p>
-          You have successfully avoided the shadowy figure's attacks and one of
-          the missed hits has loosened the lock. One more attack should do it.
-        </p>
-        <button onClick={next}>Continue</button>
-      </div>
-    );
-  }
-
-  if (step === 3) {
-    const p = config.phases?.[1] || { reps: 20, exercise: "Side Bunny Hops" };
-    return (
-      <div className="rpg-text room-content">
-        <p>The boss lashes out even quicker in irritation.</p>
-        <p>Complete {p.reps} {p.exercise} to stay unharmed.</p>
-        <button onClick={next}>I've done it</button>
-      </div>
-    );
-  }
-
-  if (step === 4) {
-    return (
-      <div className="rpg-text room-content">
-        <p>The boss misses and smashes the door open, the lock falling off.</p>
-        <p>You sprint down the hallway toward the fitness suite.</p>
-        <button
-          onClick={() => {
-            setGameState && setGameState((prev) => ({ ...prev, bossDefeated: true }));
-            onComplete && onComplete();
-          }}
-        >
-          Enter Fitness Suite
-        </button>
-      </div>
-    );
-  }
-
-  return null;
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>👹 Boss Fight: Mutated Mrs Roche</h2>
+      <p>🏋️ 21-15-9: Box jumps, slam balls, Calories</p>
+      <p>
+        ⚡ Missed BlazePods: {gameState.missedBlazePods} → Burn{" "}
+        {gameState.missedBlazePods * 5} calories post-fight!
+      </p>
+      <button onClick={handleDefeat}>Complete Battle</button>
+    </div>
+  );
 }
 
 export default BossFightPhase;

--- a/src/components/phases/QuizPhase.jsx
+++ b/src/components/phases/QuizPhase.jsx
@@ -183,7 +183,12 @@ function QuizPhase({ questions = [], onComplete, showImpossibleFinal = false }) 
       <div className="quiz-container">
         <h2>🎉 Quiz Complete</h2>
         <p>You answered {correctAnswers} out of {totalQuestions} correctly.</p>
-        <p>The monster suddenly barges the door. You notice the bolt loosen slightly.</p>
+        {finalWrong && (
+          <p>
+            A mutated figure charges at you! You dive aside as it smashes the
+            door open.
+          </p>
+        )}
         <button onClick={() => onComplete(correctAnswers, totalQuestions)}>Continue</button>
       </div>
     );

--- a/src/data/bossData.js
+++ b/src/data/bossData.js
@@ -4,16 +4,16 @@ export const bossData = {
       name: 'Mutated Mrs Roche',
       phases: [
         {
-          title: 'Ruler Slash',
-          description: 'Dive aside from the sweeping blow.',
-          reps: 12,
-          exercise: 'Burpees',
+          title: 'Ground Stomp',
+          description: 'Jump onto the desk to avoid the shockwave.',
+          reps: 15,
+          exercise: 'Burpee Box Jumps',
         },
         {
-          title: 'Frantic Swipes',
-          description: 'Hop quickly to avoid the flurry.',
+          title: 'Whipping Spiral',
+          description: 'Leap laterally to dodge the tail.',
           reps: 20,
-          exercise: 'Side Bunny Hops',
+          exercise: 'Lateral Bunny Hops',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- restore original single-step Roche boss fight
- revert quiz completion message referencing the door
- restore boss move titles to previous versions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852b0813f4c832f97352275173c34d3