### PR TITLE
Add corridor FitnessSuite phase

### DIFF
--- a/src/components/RoomTemplate.jsx
+++ b/src/components/RoomTemplate.jsx
@@ -7,6 +7,7 @@ import BossFightPhase from './phases/BossFightPhase';
 import WarmupDisplay from './WarmupDisplay';
 import SafeQuizEvent from './events/SafeQuizEvent';
 import { getRandomLoot } from '../data/lootTable';
+import FitnessSuite from './phases/FitnessSuite';
 
 const roomImages = {
   "Mr. Watkins' Room": '/Mr_WatkinsRoom.png',
@@ -100,7 +101,9 @@ function getLinesByKey(key) {
       ...prev,
       xp: (prev.xp || 0) + correct * 5,
     }));
-    if (boss) setStage('boss');
+    if (mapMarker === "Mrs. Roche's Room") {
+      setStage('fitnessPrep');
+    } else if (boss) setStage('boss');
     else if (lootPool) setStage('loot');
     else setStage('complete');
   };
@@ -302,6 +305,10 @@ function getLinesByKey(key) {
         showImpossibleFinal={mapMarker === "Mrs. Roche's Room"}
       />
     );
+  }
+
+  if (stage === 'fitnessPrep') {
+    return <FitnessSuite setGameState={setGameState} />;
   }
 
   if (stage === 'safePenalty') {

--- a/src/components/phases/FitnessSuite.jsx
+++ b/src/components/phases/FitnessSuite.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import ParallaxDust from "../ParallaxDust";
+import "../styles/RoomScene.css";
+import { playSound } from "../../utils";
+
+function FitnessSuite({ setGameState }) {
+  const [ready, setReady] = useState(false);
+
+  const handleReady = () => {
+    playSound('footsteps');
+    setReady(true);
+  };
+
+  const handleStart = () => {
+    playSound('alarm');
+    setGameState((prev) => ({
+      ...prev,
+      currentRoom: 'Fitness Suite',
+      showOverlay: false,
+    }));
+  };
+
+  return (
+    <div className="room-container">
+      <img src="/FitnessSuite.png" alt="Fitness Suite" className="scene-image" />
+      <ParallaxDust />
+      <div className="room-content rpg-text">
+        {!ready ? (
+          <>
+            <h2>🏃 Dash to the Fitness Suite</h2>
+            <p>You sprint down the dark corridor toward the fitness suite.</p>
+            <p>Take a breath and prepare for the hero workout.</p>
+            <button onClick={handleReady}>I'm Ready</button>
+          </>
+        ) : (
+          <>
+            <h2>🔥 Hero Workout: 21-15-9</h2>
+            <ul>
+              <li>21 Calories on Assault Bike</li>
+              <li>15 Slam Balls</li>
+              <li>9 Burpees</li>
+            </ul>
+            <button onClick={handleStart}>Start Final Battle</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default FitnessSuite;


### PR DESCRIPTION
## Summary
- add a new `FitnessSuite` phase showing the run to the fitness suite and hero workout instructions
- trigger `FitnessSuite` after Mrs Roche quiz

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852b2b7b968832f85ed57f182afec02