### PR TITLE
Add logging for workout saves

### DIFF
--- a/src/components/WorkoutLogger.jsx
+++ b/src/components/WorkoutLogger.jsx
@@ -124,6 +124,7 @@ function WorkoutLogger({
 
   const saveWorkoutToFirestore = async (workoutData) => {
     try {
+      console.log("Saving workout for:", userId, workoutData);
       await addDoc(collection(db, "students", userId, "workouts"), {
         ...workoutData,
         createdAt: serverTimestamp(),


### PR DESCRIPTION
## Summary
- log `userId` and workout data before saving

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68532dcffa3c832f9935ed4c55908c14