### PR TITLE
Add TTSLine component for Google TTS playback

### DIFF
--- a/src/components/MapIntroduction.jsx
+++ b/src/components/MapIntroduction.jsx
@@ -3,6 +3,7 @@ import ParallaxDust from "./ParallaxDust";
 import "./styles/RoomScene.css";
 import { playSound } from "../utils";
 import narrationLines from "../data/narrationLines";
+import TTSLine from "./TTSLine";
 
 function MapIntroduction({ setGameState }) {
   const handleViewMap = () => {
@@ -30,7 +31,7 @@ function MapIntroduction({ setGameState }) {
       <div className="room-content rpg-text">
         <h2>🎒 A New Beginning</h2>
         {narrationLines.general.mapIntroduction.map((line, idx) => (
-          <p key={idx}>{line}</p>
+          <TTSLine key={idx} text={line} />
         ))}
         <button onClick={handleViewMap}>View Map and Begin Exploring</button>
       </div>

--- a/src/components/NarrationManager.jsx
+++ b/src/components/NarrationManager.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import TTSLine from './TTSLine';
 
 function NarrationManager({ lines = [], onComplete, backgroundImage }) {
   const [index, setIndex] = useState(0);
@@ -27,7 +28,7 @@ function NarrationManager({ lines = [], onComplete, backgroundImage }) {
 
   return (
     <div className="narration-manager" onClick={advance} style={style}>
-      <p>{lines[index]}</p>
+      <TTSLine text={lines[index]} />
       {lines.length > 1 && <p className="continue-hint">(click or press space)</p>}
     </div>
   );

--- a/src/components/RoomNarrativeOverlay.jsx
+++ b/src/components/RoomNarrativeOverlay.jsx
@@ -3,6 +3,7 @@ import { GiPirateCaptain, GiBlackKnightHelm, GiNinjaHead } from "react-icons/gi"
 import "./styles/Overlay.css";
 import { playSound } from "../utils";
 import narrationLines from "../data/narrationLines";
+import TTSLine from "./TTSLine";
 
 const avatarIcons = {
   pirate: <GiPirateCaptain />,
@@ -47,7 +48,7 @@ function RoomNarrativeOverlay({ roomName, avatar, onContinue }) {
         )}
         {avatar && <div className="overlay-avatar">{avatarIcons[avatar]}</div>}
         {lines.map((line, index) => (
-          <p key={index}>{line}</p>
+          <TTSLine key={index} text={line} />
         ))}
         <button
           onClick={() => {

--- a/src/components/RoomTemplate.jsx
+++ b/src/components/RoomTemplate.jsx
@@ -10,6 +10,7 @@ import { getRandomLoot } from '../data/lootTable';
 import FitnessSuite from './phases/FitnessSuite';
 import ParallaxDust from './ParallaxDust';
 import './styles/RoomScene.css';
+import TTSLine from './TTSLine';
 
 const roomImages = {
   "Mr. Watkins' Room": '/Mr_WatkinsRoom.png',
@@ -225,7 +226,7 @@ function getLinesByKey(key) {
         {img && <img src={img} alt={mapMarker} className="scene-image" />}
         <ParallaxDust />
         <div className="room-content rpg-text">
-          <p>Log your workout. Would you like a pre-built warm up before starting?</p>
+          <TTSLine text="Log your workout. Would you like a pre-built warm up before starting?" />
           <button onClick={() => handleWarmupDecision(true)}>Yes</button>
           <button onClick={() => handleWarmupDecision(false)}>No</button>
         </div>
@@ -239,7 +240,7 @@ function getLinesByKey(key) {
         {img && <img src={img} alt={mapMarker} className="scene-image" />}
         <ParallaxDust />
         <div className="room-content rpg-text">
-          <p>What are you training? Legs, Upper Body or Both?</p>
+          <TTSLine text="What are you training? Legs, Upper Body or Both?" />
           <button onClick={() => handleFocusSelect('legs')}>Legs</button>
           <button onClick={() => handleFocusSelect('upperBody')}>Upper Body</button>
           <button onClick={() => handleFocusSelect('full')}>Both</button>
@@ -331,7 +332,7 @@ function getLinesByKey(key) {
         {img && <img src={img} alt={mapMarker} className="scene-image" />}
         <ParallaxDust />
         <div className="room-content rpg-text">
-          <p>To force the safe open, complete {failureExercise}.</p>
+          <TTSLine text={`To force the safe open, complete ${failureExercise}.`} />
           <button onClick={handlePenaltyDone}>I've done it</button>
         </div>
       </div>
@@ -348,7 +349,7 @@ function getLinesByKey(key) {
         {img && <img src={img} alt={mapMarker} className="scene-image" />}
         <ParallaxDust />
         <div className="room-content rpg-text">
-          <p>You search the room...</p>
+          <TTSLine text="You search the room..." />
           <button onClick={handleLoot}>See what you find</button>
         </div>
       </div>
@@ -363,7 +364,7 @@ function getLinesByKey(key) {
         <ParallaxDust />
         <div className="room-content rpg-text">
           {scavengeLines.map((line, i) => (
-            <p key={i}>{line}</p>
+            <TTSLine key={i} text={line} />
           ))}
           <button onClick={handleScavengeComplete}>Investigate</button>
         </div>
@@ -378,24 +379,22 @@ function getLinesByKey(key) {
         <ParallaxDust />
         <div className="room-content rpg-text">
           {loot && (
-            <p>
-              You have finished scavenging for supplies and found{' '}
-              <span className={`rarity-${loot.rarity} loot-new`}>{loot.name}</span>! This has
-              been added to your backpack for later use.
-            </p>
+            <TTSLine
+              text={`You have finished scavenging for supplies and found ${loot.name}! This has been added to your backpack for later use.`}
+            />
           )}
           {loot &&
             loot.name.includes('Map Piece') &&
             mapMarker === "Mr. Watkins' Room" && (
-              <p>
-                {narrationLines.languages.room1.foundItem.replace(
+              <TTSLine
+                text={narrationLines.languages.room1.foundItem.replace(
                   '{item}',
                   loot.name
                 )}
-              </p>
+              />
             )}
           {mapMarker === "Mr. Watkins' Room" && (
-            <p>{narrationLines.languages.room1.rest}</p>
+            <TTSLine text={narrationLines.languages.room1.rest} />
           )}
           <button
             onClick={() =>

--- a/src/components/TTSLine.jsx
+++ b/src/components/TTSLine.jsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+import { speakText } from '../utils';
+
+function TTSLine({ text, autoRead }) {
+  useEffect(() => {
+    if (autoRead) {
+      speakText(text);
+    }
+  }, [text, autoRead]);
+
+  return (
+    <p>
+      {text}{' '}
+      <button onClick={() => speakText(text)} aria-label="Play voice">
+        🔊 Play Voice
+      </button>
+    </p>
+  );
+}
+
+export default TTSLine;

--- a/src/components/events/SafeQuizEvent.jsx
+++ b/src/components/events/SafeQuizEvent.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import "../styles/SafeQuizEvent.css";
 import { playSound } from "../../utils";
+import TTSLine from "../TTSLine";
 
 const baseUrl = import.meta.env.BASE_URL || "/";
 
@@ -67,10 +68,9 @@ const SafeQuizEvent = ({
   if (quizCompleted && loot) {
     return (
       <div>
-        <p>
-          You’ve finished scavenging and discovered{' '}
-          <strong className={`rarity-${loot.rarity}`}>{loot.name}</strong>. It’s been added to your backpack for later use.
-        </p>
+        <TTSLine
+          text={`You’ve finished scavenging and discovered ${loot.name}. It’s been added to your backpack for later use.`}
+        />
         <button onClick={onComplete}>Continue</button>
       </div>
     );
@@ -79,7 +79,7 @@ const SafeQuizEvent = ({
   if (quizCompleted) {
     return (
       <div>
-        <p>{feedback}</p>
+        <TTSLine text={feedback} />
         <button onClick={onComplete}>Continue</button>
       </div>
     );
@@ -89,14 +89,14 @@ const SafeQuizEvent = ({
     <div className="safe-event">
       <img src={`${baseUrl}safe.png`} alt="Digital Safe" className="safe-image" />
       <h2>🔐 Digital Safe - {roomName}</h2>
-      <p><strong>Lives:</strong> {"❤️".repeat(lives)} {"🤍".repeat(3 - lives)}</p>
-      <p>{currentQuestion?.question}</p>
+      <TTSLine text={`Lives: ${'❤️'.repeat(lives)} ${'🤍'.repeat(3 - lives)}`} />
+      <TTSLine text={currentQuestion?.question} />
       {currentQuestion?.options.map((option, index) => (
         <button key={index} onClick={() => handleAnswer(option.correct)}>
           {option.label}
         </button>
       ))}
-      {feedback && <p>{feedback}</p>}
+      {feedback && <TTSLine text={feedback} />}
     </div>
   );
 };

--- a/src/components/phases/EscapePhase.jsx
+++ b/src/components/phases/EscapePhase.jsx
@@ -3,6 +3,7 @@ import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
 import { playSound } from "../../utils";
 import narrationLines from "../../data/narrationLines";
+import TTSLine from "../TTSLine";
 
 function EscapePhase({ setGameState, slamBallGoal = 10, squatJumpGoal = 15 }) {
   const [slamBalls, setSlamBalls] = useState(0);
@@ -31,19 +32,15 @@ function EscapePhase({ setGameState, slamBallGoal = 10, squatJumpGoal = 15 }) {
       <div className="room-content rpg-text">
         <h2>🔧 Escape Options</h2>
         {narrationLines.general.escaping.slice(0,3).map((line, idx) => (
-          <p key={idx}>{line}</p>
+          <TTSLine key={idx} text={line} />
         ))}
         <div>
-          <p>
-            {narrationLines.general.escaping[3].replace('{slamBallGoal}', slamBallGoal)}
-          </p>
+          <TTSLine text={narrationLines.general.escaping[3].replace('{slamBallGoal}', slamBallGoal)} />
           <button onClick={() => setSlamBalls(slamBalls + 1)}>Do Slam Ball</button>
           <p>Progress: {slamBalls}/{slamBallGoal}</p>
         </div>
         <div>
-          <p>
-            {narrationLines.general.escaping[4].replace('{squatJumpGoal}', squatJumpGoal)}
-          </p>
+          <TTSLine text={narrationLines.general.escaping[4].replace('{squatJumpGoal}', squatJumpGoal)} />
           <button onClick={() => setJumpSquats(jumpSquats + 1)}>Do Squat Jump</button>
           <p>Progress: {jumpSquats}/{squatJumpGoal}</p>
         </div>

--- a/src/components/phases/FinalBossPhase.jsx
+++ b/src/components/phases/FinalBossPhase.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import ParallaxDust from "../ParallaxDust";
 import BlazePods from "../BlazePods";
 import { playSound, updateLifetimeSummary, logWorkoutMinutes } from "../../utils";
+import TTSLine from "../TTSLine";
 import "../styles/RoomScene.css";
 
 function FinalBossPhase({ setGameState }) {
@@ -79,12 +80,8 @@ function FinalBossPhase({ setGameState }) {
 
       {!battleStarted && (
         <>
-          <p>
-            You've successfully avoided Mrs. Roche's monstrous attacks. She stumbles, exhausted, her mutated form steaming in the cold air.
-          </p>
-          <p>
-            Now's your chance. Finish her with one final powerful Slam Ball to end the nightmare. Begin your final workout now!
-          </p>
+          <TTSLine text="You've successfully avoided Mrs. Roche's monstrous attacks. She stumbles, exhausted, her mutated form steaming in the cold air." />
+          <TTSLine text="Now's your chance. Finish her with one final powerful Slam Ball to end the nightmare. Begin your final workout now!" />
           <button onClick={handleStart} className="start-btn">
             Start Boss Battle
           </button>
@@ -93,7 +90,7 @@ function FinalBossPhase({ setGameState }) {
 
       {battleStarted && !battleFinished && (
         <>
-          <p>⏱️ Time Elapsed: <strong>{timer}s</strong></p>
+          <TTSLine text={`⏱️ Time Elapsed: ${timer}s`} />
           <button onClick={handleFinish} className="finish-btn">
             Finish Workout
           </button>
@@ -104,14 +101,11 @@ function FinalBossPhase({ setGameState }) {
           <>
             <div className="victory-summary">
               <h3>🎉 Victory Achieved!</h3>
-            <p>Mutated Mrs. Roche collapses in defeat, the air clearing as silence returns.</p>
-            <p>You completed <strong>Operation Slamstorm</strong> in <strong>{timer} seconds</strong>.</p>
-            <p>Your heroic effort has been immortalized on the school leaderboard.</p>
+            <TTSLine text="Mutated Mrs. Roche collapses in defeat, the air clearing as silence returns." />
+            <TTSLine text={`You completed Operation Slamstorm in ${timer} seconds.`} />
+            <TTSLine text="Your heroic effort has been immortalized on the school leaderboard." />
             </div>
-            <p>
-              You’ve finished scavenging and discovered{' '}
-              <span className="rarity-rare loot-new">Map Piece #2 (Maths Department)</span>. It’s been added to your backpack for later use.
-            </p>
+            <TTSLine text="You’ve finished scavenging and discovered Map Piece #2 (Maths Department). It’s been added to your backpack for later use." />
           </>
         )}
         </div>

--- a/src/components/phases/IntroPhase.jsx
+++ b/src/components/phases/IntroPhase.jsx
@@ -3,6 +3,7 @@ import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
 import { playVoice, playSound } from "../../utils";
 import narrationLines from "../../data/narrationLines";
+import TTSLine from "../TTSLine";
 
 function IntroPhase({ setGameState }) {
   useEffect(() => {
@@ -15,7 +16,7 @@ function IntroPhase({ setGameState }) {
       <div className="room-content rpg-text">
         <h2>🧊 Locked In</h2>
         {narrationLines.general.introPhase.map((line, idx) => (
-          <p key={idx}>{line}</p>
+          <TTSLine key={idx} text={line} />
         ))}
         <button onClick={() => {
           playSound('footsteps');

--- a/src/components/phases/MobilityPhase.jsx
+++ b/src/components/phases/MobilityPhase.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
 import { playSound } from "../../utils";
+import TTSLine from "../TTSLine";
 
 function MobilityPhase({ setGameState }) {
   const handleGrabObject = () => {
@@ -16,11 +17,8 @@ function MobilityPhase({ setGameState }) {
       <ParallaxDust />
       <div className="room-content rpg-text">
         <h2>🔎 Hidden Object</h2>
-        <p>
-          As you explore the changing room, you spot a locker tipped on its side—
-          underneath, something shiny glints in the flickering light.
-        </p>
-        <p>You reach carefully under the locker and feel a cold metal tool.</p>
+        <TTSLine text="As you explore the changing room, you spot a locker tipped on its side— underneath, something shiny glints in the flickering light." />
+        <TTSLine text="You reach carefully under the locker and feel a cold metal tool." />
         <button onClick={handleGrabObject}>Take the object</button>
       </div>
     </div>

--- a/src/components/phases/VictoryPhase.jsx
+++ b/src/components/phases/VictoryPhase.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { playSound } from "../../utils";
+import TTSLine from "../TTSLine";
 
 function VictoryPhase({ gameState }) {
   useEffect(() => {
@@ -8,7 +9,7 @@ function VictoryPhase({ gameState }) {
   return (
     <div style={{ padding: 20 }}>
       <h2>🎉 Victory!</h2>
-      <p>You earn:</p>
+      <TTSLine text="You earn:" />
       <ul>
         {gameState.lootUnlocked.map((item, i) => (
           <li key={i}>{item}</li>

--- a/src/components/phases/WarmUpPhase.jsx
+++ b/src/components/phases/WarmUpPhase.jsx
@@ -3,6 +3,7 @@ import ParallaxDust from "../ParallaxDust";
 import "../styles/RoomScene.css";
 import { playSound } from "../../utils";
 import narrationLines from "../../data/narrationLines";
+import TTSLine from "../TTSLine";
 
 function WarmUpPhase({ setGameState }) {
   useEffect(() => {
@@ -19,7 +20,7 @@ function WarmUpPhase({ setGameState }) {
       <div className="room-content rpg-text">
         <h2>🔥 Warm-Up</h2>
         {narrationLines.general.warmupIntro.map((line, idx) => (
-          <p key={idx}>{line}</p>
+          <TTSLine key={idx} text={line} />
         ))}
         <button onClick={() => setGameState((prev) => ({ ...prev, introStage: 2 }))}>
           I've rowed 500m

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,46 +51,42 @@ export function playVoice(filePath) {
   audio.play().catch(() => {});
 }
 
-// Speak the provided text using Google Text-to-Speech REST API
-// Requires VITE_GOOGLE_TTS_KEY environment variable containing an API key
+// Speak text using the backend /speak endpoint which proxies Google TTS
 export async function speakText(text) {
   if (typeof fetch === 'undefined') return;
-  const apiKey = import.meta.env.VITE_GOOGLE_TTS_KEY;
-  if (!apiKey) {
-    if ('speechSynthesis' in window) {
+
+  try {
+    const response = await fetch('/speak', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, voice: 'en-GB-Wavenet-D' }),
+    });
+
+    // Try handling both raw blobs and JSON { audioContent }
+    const contentType = response.headers.get('Content-Type') || '';
+    let audioUrl = null;
+
+    if (contentType.includes('application/json')) {
+      const data = await response.json();
+      if (data.audioContent) {
+        audioUrl = `data:audio/mp3;base64,${data.audioContent}`;
+      }
+    } else {
+      const blob = await response.blob();
+      audioUrl = URL.createObjectURL(blob);
+    }
+
+    if (audioUrl) {
+      const audio = new Audio(audioUrl);
+      audio.play().catch(() => {});
+    } else if ('speechSynthesis' in window) {
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.lang = 'en-GB';
       utterance.rate = 0.8;
       window.speechSynthesis.speak(utterance);
     }
-    return;
-  }
-
-  try {
-    const response = await fetch(
-      `https://texttospeech.googleapis.com/v1/text:synthesize?key=${apiKey}`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          input: { text },
-          voice: {
-            languageCode: 'en-GB',
-            name: 'en-GB-Wavenet-B',
-            ssmlGender: 'MALE',
-          },
-          audioConfig: { audioEncoding: 'MP3', speakingRate: 0.8 },
-        }),
-      }
-    );
-
-    const data = await response.json();
-    if (data.audioContent) {
-      const audio = new Audio(`data:audio/mp3;base64,${data.audioContent}`);
-      audio.play().catch(() => {});
-    }
   } catch (err) {
-    console.error('Failed to speak text with Google TTS', err);
+    console.error('Failed to speak text via backend', err);
     if ('speechSynthesis' in window) {
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.lang = 'en-GB';


### PR DESCRIPTION
## Summary
- create `TTSLine` component with a "Play Voice" button
- update utils `speakText` to call backend `/speak` endpoint using UK voice
- render narrative text with `TTSLine` across phases and events
- use TTSLine in NarrationManager and Room templates

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853354438b8832f8c14ac168473cfe0