### PR TITLE
Add Firestore workout logging and leaderboard

### DIFF
--- a/src/components/Leaderboard.jsx
+++ b/src/components/Leaderboard.jsx
@@ -1,94 +1,46 @@
-import React, { useState } from "react";
-import "./styles/Leaderboard.css";
+import { useEffect, useState } from 'react';
+import {
+  collection,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  limit
+} from 'firebase/firestore';
+import { db } from '../firebase';
+import './styles/Leaderboard.css';
 
-const sampleStats = [
-  { name: "Alice", year: 7, gender: "F", totalWeightMonth: 2200, totalWeightAll: 12000, totalDistanceMonth: 15, totalDistanceAll: 80, bossKillTime: 90 },
-  { name: "Bob", year: 8, gender: "M", totalWeightMonth: 3400, totalWeightAll: 20000, totalDistanceMonth: 25, totalDistanceAll: 140, bossKillTime: 110 },
-  { name: "Charlie", year: 9, gender: "M", totalWeightMonth: 3000, totalWeightAll: 15000, totalDistanceMonth: 20, totalDistanceAll: 120, bossKillTime: 95 },
-  { name: "Daisy", year: 10, gender: "F", totalWeightMonth: 2800, totalWeightAll: 18000, totalDistanceMonth: 30, totalDistanceAll: 200, bossKillTime: 88 },
-  { name: "Evan", year: 11, gender: "M", totalWeightMonth: 4100, totalWeightAll: 22000, totalDistanceMonth: 35, totalDistanceAll: 250, bossKillTime: 80 },
-];
+function Leaderboard({ yearGroup }) {
+  const [entries, setEntries] = useState([]);
 
-function Leaderboard() {
-  const [year, setYear] = useState("all");
-  const [gender, setGender] = useState("all");
-
-  const filtered = sampleStats.filter((p) => {
-    const yearMatch = year === "all" || p.year.toString() === year;
-    const genderMatch = gender === "all" || p.gender === gender;
-    return yearMatch && genderMatch;
-  });
-
-  const sortBy = (field, asc = false) => {
-    const sorted = [...filtered].sort((a, b) => {
-      if (asc) return a[field] - b[field];
-      return b[field] - a[field];
+  useEffect(() => {
+    const q = query(
+      collection(db, 'workouts'),
+      where('yearGroup', '==', yearGroup),
+      orderBy('timestamp', 'desc'),
+      limit(50)
+    );
+    const unsubscribe = onSnapshot(q, snap => {
+      const data = snap.docs.map(doc => ({
+        id: doc.id,
+        ...doc.data()
+      }));
+      setEntries(data);
     });
-    return sorted.slice(0, 5);
-  };
+    return unsubscribe;
+  }, [yearGroup]);
 
   return (
     <div className="leaderboard-container">
-      <h2>🏅 Fitness Leaderboard</h2>
-      <div className="lb-filters">
-        <select value={year} onChange={(e) => setYear(e.target.value)}>
-          <option value="all">All Years</option>
-          <option value="7">Year 7</option>
-          <option value="8">Year 8</option>
-          <option value="9">Year 9</option>
-          <option value="10">Year 10</option>
-          <option value="11">Year 11</option>
-        </select>
-        <select value={gender} onChange={(e) => setGender(e.target.value)}>
-          <option value="all">All</option>
-          <option value="M">Male</option>
-          <option value="F">Female</option>
-        </select>
-      </div>
-      <div className="lb-grids">
-        <div className="lb-section">
-          <h3>Weight Lifted (Month)</h3>
-          <ol>
-            {sortBy("totalWeightMonth").map((p, i) => (
-              <li key={i}>{p.name} - {p.totalWeightMonth} kg</li>
-            ))}
-          </ol>
-        </div>
-        <div className="lb-section">
-          <h3>Weight Lifted (All Time)</h3>
-          <ol>
-            {sortBy("totalWeightAll").map((p, i) => (
-              <li key={i}>{p.name} - {p.totalWeightAll} kg</li>
-            ))}
-          </ol>
-        </div>
-        <div className="lb-section">
-          <h3>Cardio Distance (Month)</h3>
-          <ol>
-            {sortBy("totalDistanceMonth").map((p, i) => (
-              <li key={i}>{p.name} - {p.totalDistanceMonth} km</li>
-            ))}
-          </ol>
-        </div>
-        <div className="lb-section">
-          <h3>Cardio Distance (All Time)</h3>
-          <ol>
-            {sortBy("totalDistanceAll").map((p, i) => (
-              <li key={i}>{p.name} - {p.totalDistanceAll} km</li>
-            ))}
-          </ol>
-        </div>
-        <div className="lb-section">
-          <h3>Fastest Boss Defeat</h3>
-          <ol>
-            {sortBy("bossKillTime", true).map((p, i) => (
-              <li key={i}>{p.name} - {p.bossKillTime}s</li>
-            ))}
-          </ol>
-        </div>
-      </div>
+      <h2>Year {yearGroup} Leaderboard</h2>
+      <ol>
+        {entries.map(e => (
+          <li key={e.id}>
+            {e.userId}: {e.workoutType || e.type} — {e.caloriesBurned || e.totalWeightLifted}
+          </li>
+        ))}
+      </ol>
     </div>
   );
 }
-
 export default Leaderboard;

--- a/src/components/RoomTemplate.jsx
+++ b/src/components/RoomTemplate.jsx
@@ -272,6 +272,7 @@ function getLinesByKey(key) {
             setGameState={setGameState}
             workoutFocus={workoutFocus || gameState.workoutFocus}
             userId={userId}
+            yearGroup={gameState.yearGroup}
             onComplete={handleWorkoutComplete}
             completeLabel="Upload Your Workout"
           />

--- a/src/components/SignIn.jsx
+++ b/src/components/SignIn.jsx
@@ -5,6 +5,7 @@ import LifetimeSummaryPanel from "./LifetimeSummaryPanel";
 
 function SignIn({ onSignIn }) {
   const [username, setUsername] = useState("");
+  const [yearGroup, setYearGroup] = useState("Year 7");
 
 
   return (
@@ -17,10 +18,17 @@ function SignIn({ onSignIn }) {
           onChange={(e) => setUsername(e.target.value)}
         />
         <input placeholder="Password" type="password" />
+        <select value={yearGroup} onChange={(e) => setYearGroup(e.target.value)}>
+          <option value="Year 7">Year 7</option>
+          <option value="Year 8">Year 8</option>
+          <option value="Year 9">Year 9</option>
+          <option value="Year 10">Year 10</option>
+          <option value="Year 11">Year 11</option>
+        </select>
         <button onClick={() => onSignIn(username)}>Sign In</button>
       </div>
       <LifetimeSummaryPanel userId={username} username={username || "Player"} />
-      <Leaderboard />
+      <Leaderboard yearGroup={yearGroup} />
     </div>
   );
 }

--- a/src/components/WorkoutLogger.jsx
+++ b/src/components/WorkoutLogger.jsx
@@ -19,6 +19,7 @@ function WorkoutLogger({
   setGameState,
   workoutFocus,
   userId,
+  yearGroup,
   onComplete,
   completeLabel = "Continue",
 }) {
@@ -125,9 +126,11 @@ function WorkoutLogger({
   const saveWorkoutToFirestore = async (workoutData) => {
     try {
       console.log("Saving workout for:", userId, workoutData);
-      await addDoc(collection(db, "students", userId, "workouts"), {
+      await addDoc(collection(db, "workouts"), {
+        userId,
+        yearGroup,
         ...workoutData,
-        createdAt: serverTimestamp(),
+        timestamp: serverTimestamp(),
       });
       console.log("✅ Workout successfully logged in Firestore");
     } catch (error) {


### PR DESCRIPTION
## Summary
- log workouts to Firestore under a top-level `workouts` collection
- accept `yearGroup` in `WorkoutLogger` and `SignIn`
- allow leaderboard to stream results from Firestore

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68533933f3b0832faef6fa65802d232c