### PR TITLE
Refine cinematic start screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ import AccountabilityPopup from "./components/AccountabilityPopup";
 import BadgeUnlockedModal from "./components/BadgeUnlockedModal";
 import { playSound, stopSound, setMuted } from "./utils";
 import GlobalAudioControls from "./components/GlobalAudioControls";
-import HomePage from "./components/HomePage";
+import StartScreen from "./components/StartScreen";
 
 const INITIAL_STATE = {
   characterCreated: false,
@@ -154,7 +154,7 @@ function App() {
   const renderPhase = () => {
     if (!user) {
       if (showHome) {
-        return <HomePage onStart={() => setShowHome(false)} />;
+        return <StartScreen onStart={() => setShowHome(false)} />;
       }
       return <LoginForm onLogin={(u) => setUser(u)} />;
     }

--- a/src/components/StartScreen.jsx
+++ b/src/components/StartScreen.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from "react";
+import styles from "./StartScreen.module.css";
+import logo from "/pencoedtre_high_logo.svg";
+
+export default function StartScreen({ onStart }) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      document.body.classList.add(styles.loaded);
+    }, 50);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.overlay} />
+      <div className={styles.content}>
+        <img src={logo} alt="Pencoedtre High Logo" className={styles.badge} />
+        <h1 className={styles.title}>Fitness RPG</h1>
+        <p className={styles.subtitle}>Begin your adventure to fitness glory.</p>
+        <button
+          className={styles.startButton}
+          onClick={onStart}
+          aria-label="Start Game"
+        >
+          Start
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/StartScreen.module.css
+++ b/src/components/StartScreen.module.css
@@ -1,0 +1,92 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
+.container {
+  position: relative;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: url('/global-bg.png') center/cover no-repeat fixed;
+  overflow: hidden;
+  text-align: center;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.content {
+  position: relative;
+  max-width: 700px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: #f5f5f5;
+  font-family: 'Inter', 'Roboto', sans-serif;
+  animation: fadeIn 1s ease-out forwards;
+  opacity: 0;
+}
+
+.badge {
+  width: 110px;
+  height: 110px;
+  object-fit: contain;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  margin-bottom: 20px;
+}
+
+.title {
+  font-size: 3rem;
+  font-weight: 700;
+  margin: 0 0 10px;
+}
+
+.subtitle {
+  margin-bottom: 40px;
+}
+
+.startButton {
+  padding: 12px 32px;
+  font-size: 1.2rem;
+  background-color: #388e3c;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  transition: box-shadow 0.3s, transform 0.3s;
+  animation: fadeIn 1.5s ease-out forwards;
+  opacity: 0;
+}
+
+.startButton:hover {
+  box-shadow: 0 0 10px rgba(56, 142, 60, 0.8);
+}
+
+.startButton:focus {
+  outline: 3px solid #fff;
+  outline-offset: 2px;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (max-width: 768px) {
+  .title {
+    font-size: 2.2rem;
+  }
+  .subtitle {
+    font-size: 1rem;
+  }
+}
+
+.loaded .content,
+.loaded .startButton {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- create new `StartScreen` component styled via CSS modules
- add responsive visual design with overlay, animations and fonts
- use the new screen in `App.jsx`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68541c779340832f86900cac18153bfd