### PR TITLE
Remove tracked .env and add sample

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,0 @@
-VITE_FIREBASE_API_KEY=AIzaSyBI5P4HiwnMBZhQh5V2KOn-0_21-qRkDdc
-VITE_FIREBASE_AUTH_DOMAIN=fitness-rpg-pencoedtre.firebaseapp.com
-VITE_FIREBASE_PROJECT_ID=fitness-rpg-pencoedtre
-VITE_FIREBASE_STORAGE_BUCKET=fitness-rpg-pencoedtre.appspot.com
-VITE_FIREBASE_MESSAGING_SENDER_ID=255197443274
-VITE_FIREBASE_APP_ID=1:255197443274:web:212a893767d6f55f25f033
-
-# Optional for narration TTS
-VITE_GOOGLE_TTS_KEY=  # You can paste your Google TTS key here later

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+VITE_FIREBASE_API_KEY=<your-api-key>
+VITE_FIREBASE_AUTH_DOMAIN=<your-auth-domain>
+VITE_FIREBASE_PROJECT_ID=<your-project-id>
+VITE_FIREBASE_STORAGE_BUCKET=<your-storage-bucket>
+VITE_FIREBASE_MESSAGING_SENDER_ID=<your-sender-id>
+VITE_FIREBASE_APP_ID=<your-app-id>
+
+# Optional for narration TTS
+VITE_GOOGLE_TTS_KEY=

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ who are visually impaired.
 
 ### Firebase Configuration
 
-Create a `.env` file (or copy `.env.example`) with the following variables set
-to your Firebase project details:
+Copy `.env.example` to `.env` and replace the placeholders with your
+own Firebase project details:
 
 ```bash
 VITE_FIREBASE_API_KEY=<your-api-key>


### PR DESCRIPTION
## Summary
- remove `.env` from version control
- add `.env.example` with placeholder Firebase vars
- document copying the example file in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68548a96bc1c832f957dff55539b124e