### PR TITLE
Use built-in fetch, require Node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The goal of this project is to combine a simple RPG style narrative with fitness
 
 ## Setup
 
-1. Install [Node.js](https://nodejs.org/) (version 16 or higher is recommended).
+1. Install [Node.js](https://nodejs.org/) (version 18 or higher is required).
 2. Run `npm install` from the project root to install dependencies.
 3. Start the development server with `npm run dev`.
 4. Open the provided local address (usually `http://localhost:5173`) in your browser to play.

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import fetch from 'node-fetch';
 import dotenv from 'dotenv';
 
 dotenv.config();


### PR DESCRIPTION
## Summary
- remove the `node-fetch` import in `server.js`
- document Node 18 requirement in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68548a99e788832fb8a0ce88c35a55c2