### PR TITLE
Fix server to serve built app

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,8 +7,22 @@ const app = express();
 app.use(express.json());
 
 // Development server for serving the built site
+// Serve the files from the dist directory produced by `npm run build`
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-app.use(express.static('public'));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const distPath = path.join(__dirname, 'dist');
+
+app.use(express.static(distPath));
+
+// Fallback to index.html so client-side routing works
+// Send index.html for any unmatched route
+app.use((_, res) => {
+  res.sendFile(path.join(distPath, 'index.html'));
+});
 
 app.listen(5174, () => {
   console.log('Server running on http://localhost:5174');


### PR DESCRIPTION
## Summary
- serve `dist` directory in `server.js` so Express correctly hosts the built app
- add fallback route to return `index.html` for client-side routing

## Testing
- `npm test -- -t ''`
- `node server.js` (verified start message)

------
https://chatgpt.com/codex/tasks/task_e_6855c7ba3274832f89960839a4bc5b1d