### PR TITLE
Improve login error handling

### DIFF
--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,23 +1,42 @@
 import React, { useState } from "react";
-import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from "firebase/auth";
+import {
+  fetchSignInMethodsForEmail,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+} from "firebase/auth";
 import { auth } from "../firebase";
 
 export default function LoginForm({ onLogin }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
 
   const handleLogin = async (e) => {
     e.preventDefault();
+    setLoading(true);
+    setErrorMessage("");
     try {
-      const result = await signInWithEmailAndPassword(auth, email, password);
-      onLogin(result.user);
-    } catch (err) {
-      try {
-        const result = await createUserWithEmailAndPassword(auth, email, password);
-        onLogin(result.user);
-      } catch (error) {
-        alert("Login failed: " + error.message);
+      const methods = await fetchSignInMethodsForEmail(auth, email);
+      let cred;
+      if (methods.length === 0) {
+        cred = await createUserWithEmailAndPassword(auth, email, password);
+      } else {
+        cred = await signInWithEmailAndPassword(auth, email, password);
       }
+      onLogin(cred.user);
+    } catch (error) {
+      if (error.code === "auth/wrong-password") {
+        setErrorMessage("Incorrect password.");
+      } else if (error.code === "auth/network-request-failed") {
+        setErrorMessage("Network error. Please try again.");
+      } else if (error.code === "auth/user-not-found") {
+        setErrorMessage("Account not found.");
+      } else {
+        setErrorMessage(error.message);
+      }
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -38,7 +57,10 @@ export default function LoginForm({ onLogin }) {
         onChange={(e) => setPassword(e.target.value)}
         required
       />
-      <button type="submit">Log In</button>
+      <button type="submit" disabled={loading}>
+        {loading ? "Loading..." : "Log In"}
+      </button>
+      {errorMessage && <p className="error">{errorMessage}</p>}
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- add error handling for account sign in
- create account automatically if email doesn't exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855cd915bb4832fba7cc8e1a259e64e