### PR TITLE
Remove Firebase API key log

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -3,8 +3,6 @@ import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 import { getStorage } from "firebase/storage";
 
-console.log("\ud83d\udd11 Firebase API Key:", import.meta.env.VITE_FIREBASE_API_KEY);
-
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,


### PR DESCRIPTION
## Summary
- remove console log exposing Firebase API key

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685930322864832f984598a73bbad964