### PR TITLE
Switch to pamphlet map background

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -67,7 +67,7 @@ function Map({ gameState, setGameState }) {
     <div className="map-container">
       <h2 className="map-title">🗺️ School Map</h2>
       <div className="map">
-        <img src="/PamphletMap.png" alt="School Map Pamphlet" className="map-background" />
+        <img src="/Pamphletmap.png" alt="School Map Pamphlet" className="map-background" />
         {dynamicRooms.map((room, index) => (
           <div
             key={index}

--- a/src/components/styles/Map.css
+++ b/src/components/styles/Map.css
@@ -17,6 +17,23 @@
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
+/* Map image and container */
+.map {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.map-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 0;
+}
+
 /* Title Styling */
 .map-title {
   font-size: 22px;
@@ -32,6 +49,7 @@
 /* Individual Room Styling */
 .room {
   position: absolute;
+  z-index: 1;
   padding: 10px;
   cursor: pointer;
   border-radius: 5px;
@@ -90,6 +108,7 @@
 /* Annotation Styling */
 .annotation {
   position: absolute;
+  z-index: 1;
   background-color: rgba(0, 0, 0, 0.8);
   padding: 6px;
   border-radius: 3px;


### PR DESCRIPTION
## Summary
- display new `Pamphletmap.png` image in the map view
- add styling rules for the map container and background image
- ensure room and annotation layers appear above the map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a7f303dfc832f85bf4f86f7e76fb1